### PR TITLE
Fix empty schema error log

### DIFF
--- a/lumber-update.js
+++ b/lumber-update.js
@@ -47,7 +47,7 @@ program
 
   if (_.isEmpty(schema)) {
     console.log('💀  Oops, your database is empty. Please, ' +
-      'create some tables before running Lumber generate.💀');
+      'create some tables before running Lumber update.💀');
     process.exit(1);
   }
 


### PR DESCRIPTION
Update `lumber update` error log when database is empty:

`💀  Oops, your database is empty. Please, create some tables before running Lumber update.💀`

instead of

`💀  Oops, your database is empty. Please, create some tables before running Lumber generate.💀`


`generate` => `update`