### PR TITLE
changed PORT to FOREST_PORT in bin/www

### DIFF
--- a/templates/app/bin/www
+++ b/templates/app/bin/www
@@ -48,7 +48,7 @@ function onListening() {
     'http://app.forestadmin.com 🌳'))
 }
 
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(process.env.FOREST_PORT || '3000');
 app.set('port', port);
 
 var server = http.createServer(app);


### PR DESCRIPTION
Submitted as a fix for #125 

Overall I think a config system for tracking env var names would be a more robust solution, but this fixes the issue at hand.

If you want to reproduce the bug just make sure $PORT is unset, do a fresh install of lumber, specify a custom port in the setup and then try to run the server, it should error out.