### PR TITLE
Lumber reads .env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Improvement - Reduce the number of http requests to init the project.
 - Technical - Rename environment variable SERVER_HOST to FOREST_URL.
 
+### Fixed
+- Command Update - Environment variables are now read in from the .env file if the file exists.
+
 ## Release 1.14.1
 ### Fixed
 - Command Update - Add the 'ssl' prompt option.

--- a/lumber-update.js
+++ b/lumber-update.js
@@ -1,5 +1,4 @@
 const P = require('bluebird');
-const dotenv = require('dotenv');
 const program = require('commander');
 const chalk = require('chalk');
 const DB = require('./services/db');
@@ -15,9 +14,6 @@ program
   .parse(process.argv);
 
 (async () => {
-  // Load the environment variables from the .env to avoid always asking for the DB
-  // connection information.
-  dotenv.load();
   if (process.env.DATABASE_URL) {
     program.connectionUrl = true;
   }

--- a/lumber.js
+++ b/lumber.js
@@ -7,6 +7,9 @@
 
 const program = require('commander');
 const packagejson = require('./package.json');
+const dotenv = require('dotenv');
+
+dotenv.load();
 
 program
   .version(packagejson.version)

--- a/lumber.js
+++ b/lumber.js
@@ -5,11 +5,9 @@
 //    |  |__|  |  | | | | __ -|   __|    -|
 //    |_____|_____|_|_|_|_____|_____|__|__|
 
+require('dotenv').load();
 const program = require('commander');
 const packagejson = require('./package.json');
-const dotenv = require('dotenv');
-
-dotenv.load();
 
 program
   .version(packagejson.version)


### PR DESCRIPTION
While attempting to use `lumber generate --connection-url`, I discovered that the program did not correctly read in the `.env` file. While this may not be a typical use case (I suspect that the most common use case is to run the generate command from a generic directory without a .env file), I have been running the `generate` command repeatedly as our project has evolved, and it would be really useful to have the code in the `Prompter` class work, which is already capable of pulling the connection string from the env.

This change also appears to have fixed an issue I was seeing with `lumber update --connection-url`. Prior to this change, I was still getting prompted to input the connection url in the terminal. However, with this change in place, the environment variable is getting read correctly and used by the program as expected. I have not taken the time to uncover why it wasn't working before and subsequently why it is now working, but it is working as expected now with these changes applied, so that's good.