### PR TITLE
Fix prompter

### DIFF
--- a/services/prompter.js
+++ b/services/prompter.js
@@ -74,24 +74,6 @@ async function Prompter(program, requests) {
       }
     }
 
-    if (isRequested('dbSchema')) {
-      if (process.env.DATABASE_SCHEMA) {
-        envConfig.dbSchema = process.env.DATABASE_SCHEMA;
-      } else {
-        prompts.push({
-          type: 'input',
-          name: 'dbSchema',
-          message: 'What\'s the database schema? [optional]',
-          description: 'Leave blank by default',
-          when: answers => answers.dbDialect !== 'sqlite' && answers.dbDialect !== 'mongodb',
-          default: (args) => {
-            if (args.dbDialect === 'postgres') { return 'public'; }
-            return '';
-          },
-        });
-      }
-    }
-
     if (isRequested('dbHostname')) {
       if (process.env.FOREST_DB_HOSTNAME) {
         envConfig.dbHostname = process.env.FOREST_DB_HOSTNAME;
@@ -173,157 +155,175 @@ async function Prompter(program, requests) {
         });
       }
     }
+  }
 
-    if (isRequested('ssl')) {
-      if (process.env.FOREST_DB_SSL) {
-        envConfig.ssl = process.env.FOREST_DB_SSL;
-      } else {
-        prompts.push({
-          type: 'confirm',
-          name: 'ssl',
-          message: 'Does your database require a SSL connection? ',
-          when: answers => answers.dbDialect !== 'sqlite',
-          default: false,
-        });
-      }
+  if (isRequested('dbSchema')) {
+    if (process.env.DATABASE_SCHEMA) {
+      envConfig.dbSchema = process.env.DATABASE_SCHEMA;
+    } else {
+      prompts.push({
+        type: 'input',
+        name: 'dbSchema',
+        message: 'What\'s the database schema? [optional]',
+        description: 'Leave blank by default',
+        when: answers => answers.dbDialect !== 'sqlite' && answers.dbDialect !== 'mongodb',
+        default: (args) => {
+          if (args.dbDialect === 'postgres') { return 'public'; }
+          return '';
+        },
+      });
     }
+  }
 
-    if (isRequested('mongodbSrv')) {
-      if (process.env.FOREST_DB_MONGODB_SRV) {
-        envConfig.mongodbSrv = process.env.FOREST_MONGODB_SRV;
-      } else {
-        prompts.push({
-          type: 'confirm',
-          name: 'mongodbSrv',
-          message: 'Use a SRV connection string? ',
-          when: answers => answers.dbDialect === 'mongodb',
-          default: false,
-        });
-      }
+  if (isRequested('ssl')) {
+    if (process.env.FOREST_DB_SSL) {
+      envConfig.ssl = process.env.FOREST_DB_SSL;
+    } else {
+      prompts.push({
+        type: 'confirm',
+        name: 'ssl',
+        message: 'Does your database require a SSL connection? ',
+        when: answers => answers.dbDialect !== 'sqlite',
+        default: false,
+      });
     }
+  }
 
-    if (isRequested('dbStorage')) {
-      if (process.env.FOREST_STORAGE) {
-        envConfig.dbStorage = process.env.FOREST_STORAGE;
-      } else {
-        prompts.push({
-          type: 'input',
-          name: 'dbStorage',
-          when: answers => answers.dbDialect === 'sqlite',
-          message: 'What\'s the full path of your SQLite file?',
-          validate: (dbStorage) => {
-            if (dbStorage) { return true; }
-            return '🔥  Hey, you need to specify a database SQLite file 🔥';
-          },
-        });
-      }
+  if (isRequested('mongodbSrv')) {
+    if (process.env.FOREST_DB_MONGODB_SRV) {
+      envConfig.mongodbSrv = process.env.FOREST_MONGODB_SRV;
+    } else {
+      prompts.push({
+        type: 'confirm',
+        name: 'mongodbSrv',
+        message: 'Use a SRV connection string? ',
+        when: answers => answers.dbDialect === 'mongodb',
+        default: false,
+      });
     }
+  }
 
-    if (isRequested('appHostname')) {
-      if (process.env.FOREST_HOSTNAME) {
-        envConfig.appHostname = process.env.FOREST_HOSTNAME;
-      } else {
-        prompts.push({
-          type: 'input',
-          name: 'appHostname',
-          message: 'What\'s the IP/hostname on which your back office will be running? ',
-          default: 'localhost',
-        });
-      }
+  if (isRequested('dbStorage')) {
+    if (process.env.FOREST_STORAGE) {
+      envConfig.dbStorage = process.env.FOREST_STORAGE;
+    } else {
+      prompts.push({
+        type: 'input',
+        name: 'dbStorage',
+        when: answers => answers.dbDialect === 'sqlite',
+        message: 'What\'s the full path of your SQLite file?',
+        validate: (dbStorage) => {
+          if (dbStorage) { return true; }
+          return '🔥  Hey, you need to specify a database SQLite file 🔥';
+        },
+      });
     }
+  }
 
-    if (isRequested('appPort')) {
-      if (process.env.FOREST_PORT) {
-        envConfig.appPort = process.env.FOREST_PORT;
-      } else {
-        prompts.push({
-          type: 'input',
-          name: 'appPort',
-          message: 'What\'s the port on which your back office will be running? ',
-          default: '3000',
-          validate: (port) => {
-            if (!/^\d+$/.test(port)) {
-              return '🔥  Oops, the port must be a number 🔥';
-            }
-
-            const parsedPort = parseInt(port, 10);
-            if (parsedPort > 0 && parsedPort < 65536) { return true; }
-            return '🔥  Oops, this is not a valid port 🔥';
-          },
-        });
-      }
+  if (isRequested('appHostname')) {
+    if (process.env.FOREST_HOSTNAME) {
+      envConfig.appHostname = process.env.FOREST_HOSTNAME;
+    } else {
+      prompts.push({
+        type: 'input',
+        name: 'appHostname',
+        message: 'What\'s the IP/hostname on which your back office will be running? ',
+        default: 'localhost',
+      });
     }
+  }
 
-    if (isRequested('appName')) {
-      if (process.env.FOREST_PROJECT) {
-        envConfig.appName = process.env.FOREST_PROJECT;
-      } else {
-        prompts.push({
-          type: 'input',
-          name: 'appName',
-          message: 'Choose a name for your back office: ',
-          validate: (projectName) => {
-            if (projectName) {
-              if (/^([A-Za-z0-9-_]+)$/.test(projectName)) { return true; }
-              return '🔥  The project name should only contains alphanumeric, ' +
+  if (isRequested('appPort')) {
+    if (process.env.FOREST_PORT) {
+      envConfig.appPort = process.env.FOREST_PORT;
+    } else {
+      prompts.push({
+        type: 'input',
+        name: 'appPort',
+        message: 'What\'s the port on which your back office will be running? ',
+        default: '3000',
+        validate: (port) => {
+          if (!/^\d+$/.test(port)) {
+            return '🔥  Oops, the port must be a number 🔥';
+          }
+
+          const parsedPort = parseInt(port, 10);
+          if (parsedPort > 0 && parsedPort < 65536) { return true; }
+          return '🔥  Oops, this is not a valid port 🔥';
+        },
+      });
+    }
+  }
+
+  if (isRequested('appName')) {
+    if (process.env.FOREST_PROJECT) {
+      envConfig.appName = process.env.FOREST_PROJECT;
+    } else {
+      prompts.push({
+        type: 'input',
+        name: 'appName',
+        message: 'Choose a name for your back office: ',
+        validate: (projectName) => {
+          if (projectName) {
+            if (/^([A-Za-z0-9-_]+)$/.test(projectName)) { return true; }
+            return '🔥  The project name should only contains alphanumeric, ' +
                 'dash and underscore characters. 🔥';
-            }
+          }
 
-            return '🔥  Please, choose a project name 🔥';
-          },
-        });
-      }
+          return '🔥  Please, choose a project name 🔥';
+        },
+      });
     }
+  }
 
-    envConfig.authToken = authenticator.getAuthToken();
+  envConfig.authToken = authenticator.getAuthToken();
 
-    if (isRequested('email')) {
-      if (!envConfig.authToken) {
-        prompts.push({
-          type: 'input',
-          name: 'email',
-          message: 'What\'s your email address? ',
-          validate: (email) => {
-            if (email) { return true; }
-            return '🔥  Please enter your email address 🔥';
-          },
-        });
-      }
+  if (isRequested('email')) {
+    if (!envConfig.authToken) {
+      prompts.push({
+        type: 'input',
+        name: 'email',
+        message: 'What\'s your email address? ',
+        validate: (email) => {
+          if (email) { return true; }
+          return '🔥  Please enter your email address 🔥';
+        },
+      });
     }
+  }
 
-    if (isRequested('passwordCreate')) {
-      if (!envConfig.authToken) {
-        prompts.push({
-          type: 'password',
-          name: 'password',
-          message: 'Choose a password: ',
-          validate: (password) => {
-            if (password) {
-              if (FORMAT_PASSWORD.test(password)) { return true; }
-              return '🔓  Your password security is too weak 🔓\n' +
+  if (isRequested('passwordCreate')) {
+    if (!envConfig.authToken) {
+      prompts.push({
+        type: 'password',
+        name: 'password',
+        message: 'Choose a password: ',
+        validate: (password) => {
+          if (password) {
+            if (FORMAT_PASSWORD.test(password)) { return true; }
+            return '🔓  Your password security is too weak 🔓\n' +
               ' Please make sure it contains at least:\n' +
               '    > 8 characters\n' +
               '    > Upper and lower case letters\n' +
               '    > Numbers';
-            }
+          }
 
-            return '🔥  Oops, your password cannot be blank 🔥';
-          },
-        });
-      }
-    }
-
-    if (isRequested('password')) {
-      prompts.push({
-        type: 'password',
-        name: 'password',
-        message: 'What\'s your password: ',
-        validate: (password) => {
-          if (password) { return true; }
           return '🔥  Oops, your password cannot be blank 🔥';
         },
       });
     }
+  }
+
+  if (isRequested('password')) {
+    prompts.push({
+      type: 'password',
+      name: 'password',
+      message: 'What\'s your password: ',
+      validate: (password) => {
+        if (password) { return true; }
+        return '🔥  Oops, your password cannot be blank 🔥';
+      },
+    });
   }
 
   const config = await inquirer.prompt(prompts);

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -177,7 +177,7 @@ async function Prompter(program, requests) {
 
   if (isRequested('ssl')) {
     if (process.env.FOREST_DB_SSL) {
-      envConfig.ssl = process.env.FOREST_DB_SSL;
+      envConfig.ssl = JSON.parse(process.env.FOREST_DB_SSL.toLowerCase());
     } else {
       prompts.push({
         type: 'confirm',


### PR DESCRIPTION
The prompter was skipping all subsequent prompts when the --connection-url
option was used. This leads to the generate command failing because the necessary
information is not collected. This PR fixes the prompter so that only
the prompts for the connection url pieces are skipped when the
--connection-url option is used.

The PR also fixes the reading in of `process.env.FOREST_DB_SSL`. It was previously left as a string, which evaluates to true for any valid string. This PR fixes that by parsing the value into a boolean.