### PR TITLE
[*]  Command Generate - Avoid foreignKey to conflict with relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Command Generate - Avoid foreignKey to conflict with relationship.
 
 ## RELEASE 2.4.0 - 2019-09-20
 ### Changed

--- a/services/database-analyzer.js
+++ b/services/database-analyzer.js
@@ -79,7 +79,7 @@ function DatabaseAnalyzer(databaseConnection, config, allowWarning) {
             const reference = {
               ref: foreignKey.foreign_table_name,
               foreignKey: foreignKey.column_name,
-              foreignKeyname: _.camelCase(foreignKey.column_name),
+              foreignKeyName: _.camelCase(foreignKey.column_name),
               as: formatAliasName(foreignKey.column_name),
             };
 

--- a/services/database-analyzer.js
+++ b/services/database-analyzer.js
@@ -83,6 +83,8 @@ function DatabaseAnalyzer(databaseConnection, config, allowWarning) {
               as: formatAliasName(foreignKey.column_name),
             };
 
+            // NOTICE: If the foreign key name and alias are the same, Sequelize will crash, we need
+            //         to handle this specific scenario generating a different foreign key name.
             if (reference.foreignKeyName === reference.as) {
               reference.foreignKeyName = `${reference.foreignKeyName}Key`;
             }

--- a/services/database-analyzer.js
+++ b/services/database-analyzer.js
@@ -79,8 +79,13 @@ function DatabaseAnalyzer(databaseConnection, config, allowWarning) {
             const reference = {
               ref: foreignKey.foreign_table_name,
               foreignKey: foreignKey.column_name,
+              foreignKeyname: _.camelCase(foreignKey.column_name),
               as: formatAliasName(foreignKey.column_name),
             };
+
+            if (reference.foreignKeyName === reference.as) {
+              reference.foreignKeyName = `${reference.foreignKeyName}Key`;
+            }
 
             if (foreignKey.foreign_column_name !== 'id') {
               reference.targetKey = foreignKey.foreign_column_name;

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -132,7 +132,7 @@ function Dumper(config) {
       const expectedConventionalForeignKeyName = underscored
         ? _.snakeCase(reference.foreignKey) : reference.foreignKey;
       const foreignKeyColumnUnconventional =
-        reference.foreignKey !== expectedConventionalForeignKeyName;
+        reference.foreignKeyName !== expectedConventionalForeignKeyName;
 
       if (reference.targetKey) {
         const expectedConventionalTargetKeyName = underscored

--- a/templates/model.txt
+++ b/templates/model.txt
@@ -30,7 +30,7 @@ module.exports = mongoose.model('<%= table %>', schema, '<%= table %>');
   Model.associate = (models) => {<% _.each(references, (reference) => { %>
     Model.belongsTo(models.<%= reference.ref %>, {
       foreignKey: {
-        name: '<%= reference.foreignKey %>',<% if (reference.foreignKeyColumnUnconventional) { %>
+        name: '<%= reference.foreignKeyName %>',<% if (reference.foreignKeyColumnUnconventional) { %>
         field: '<%= reference.foreignKey %>',<% } %>
       },<% if (reference.targetKey) { %>
       target: {


### PR DESCRIPTION
When foreignKey are generated, if they have the same name as the alias it crash the server on start