### PR TITLE
[*] Records Update - Fix `TINYINT` column update when declared as a `BOOLEAN` field in the ORM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Fixed
 - Command Generate - Avoid foreignKey to conflict with relationship.
 - Command Generate - Fix creation of project containing whitespaces.
-- Technical - Fix MySQL boolean values (Tinyint)
+- Records Update - Fix `TINYINT` column update when declared as a `BOOLEAN` field in the ORM model.
 
 ## RELEASE 2.4.0 - 2019-09-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Command Generate - Avoid foreignKey to conflict with relationship.
 - Command Generate - Fix creation of project containing whitespaces.
+- Technical - Fix MySQL boolean values (Tinyint)
 
 ## RELEASE 2.4.0 - 2019-09-20
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lumber-cli",
-  "version": "2.3.14",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -255,11 +255,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -410,15 +405,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
-    },
-    "cardinal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~1.0.0"
-      }
     },
     "chai": {
       "version": "4.1.2",
@@ -1858,9 +1844,9 @@
       }
     },
     "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -2075,66 +2061,44 @@
       }
     },
     "mysql2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-1.4.2.tgz",
-      "integrity": "sha1-teBACf1tY/AHVSU9+IVAolMmQLI=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-1.7.0.tgz",
+      "integrity": "sha512-xTWWQPjP5rcrceZQ7CSTKR/4XIDeH/cRkNH/uzvVGQ7W5c7EJ0dXeJUusk7OKhIoHj7uFKUxDVSCfLIl+jluog==",
       "requires": {
-        "cardinal": "1.0.0",
-        "denque": "^1.1.1",
-        "generate-function": "^2.0.0",
-        "iconv-lite": "^0.4.18",
-        "long": "^3.2.0",
-        "lru-cache": "^4.1.1",
-        "named-placeholders": "1.1.1",
-        "object-assign": "^4.1.1",
-        "readable-stream": "2.3.2",
-        "safe-buffer": "^5.0.1",
-        "seq-queue": "0.0.5",
-        "sqlstring": "^2.2.0"
+        "denque": "^1.4.1",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.5.0",
+        "long": "^4.0.0",
+        "lru-cache": "^5.1.1",
+        "named-placeholders": "^1.1.2",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.1"
       },
       "dependencies": {
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "readable-stream": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
-          "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
+        "iconv-lite": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
+          "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.0",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "yallist": "^3.0.2"
           }
         }
       }
     },
     "named-placeholders": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.1.tgz",
-      "integrity": "sha1-O3oNJiA910s6nfTJz7gnsvuQfmQ=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
+      "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
       "requires": {
-        "lru-cache": "2.5.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-          "integrity": "sha1-2COIrpyWC+y+oMc7uet5tsbOmus="
-        }
+        "lru-cache": "^4.1.3"
       }
     },
     "natural-compare": {
@@ -2205,7 +2169,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.6.0",
@@ -2584,21 +2549,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "redeyed": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
-      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
-      "requires": {
-        "esprima": "~3.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
-          "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
-        }
       }
     },
     "regenerator-runtime": {
@@ -3259,6 +3209,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "13.2.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mkdirp": "^0.5.1",
     "mongodb": "3.3.0",
     "mysql": "^2.11.1",
-    "mysql2": "1.4.2",
+    "mysql2": "^1.7.0",
     "pg": "^6.1.0",
     "sequelize": "git://github.com/ForestAdmin/sequelize.git#feature/support-schema",
     "superagent": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mkdirp": "^0.5.1",
     "mongodb": "3.3.0",
     "mysql": "^2.11.1",
-    "mysql2": "^1.7.0",
+    "mysql2": "1.7.0",
     "pg": "^6.1.0",
     "sequelize": "git://github.com/ForestAdmin/sequelize.git#feature/support-schema",
     "superagent": "^3.8.3",


### PR DESCRIPTION
When trying to update a field in ForestAdmin that is a `TINYINT` in a MySQL DB (which is the actual MySQL type for boolean) and declared as a `boolean` in a model of the Lumber instance, we get the following error:

> Incorrect integer value: 'false' for column 'feature_1' at row 1

See: https://github.com/sequelize/sequelize/issues/10633

This is [now fixed](https://github.com/sequelize/sequelize/issues/10633#issuecomment-483786351) in [`mysql2` package](https://www.npmjs.com/package/mysql2). Since the version upgrade is minor, we can update the latest version of `mysql2` (`1.7.0`)