### PR TITLE
[*] Technical - Fix Github repository language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/* linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 assets/* linguist-generated=true
-*.sql linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 assets/* linguist-generated=true
+*.sql linguist-detectable=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Fixed
 - Command Generate - Avoid foreignKey to conflict with relationship.
 - Command Generate - Fix creation of project containing whitespaces.
-- Technical - Fix Github repository language
+- Technical - Fix Github repository language.
 
 ## RELEASE 2.4.0 - 2019-09-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Command Generate - Avoid foreignKey to conflict with relationship.
 - Command Generate - Fix creation of project containing whitespaces.
+- Technical - Fix Github repository language
 
 ## RELEASE 2.4.0 - 2019-09-20
 ### Changed


### PR DESCRIPTION
Ignore assets in language detection.

Change this:
<img width="1012" alt="Capture d’écran 2019-10-06 à 21 10 20" src="https://user-images.githubusercontent.com/1575946/66274324-c11d7500-e87d-11e9-8aa7-e31724704593.png">
Into this:
<img width="1020" alt="Capture d’écran 2019-10-06 à 21 10 31" src="https://user-images.githubusercontent.com/1575946/66274326-c7abec80-e87d-11e9-9cb8-cc5907b3a36f.png">

❗️ _You can not see this change by switching to this branch! It [only works on default branch](https://github.com/github/linguist/issues/4663#issuecomment-538429590). Even after the merge, [you will have to wait](https://github.com/github/linguist/issues/4663#issuecomment-538432674) to see the change. More info in the issue I opened here: https://github.com/github/linguist/issues/4663_