### PR TITLE
[*] Technical - Fix `mysql2` version in generated `package.json`

### DIFF
--- a/services/dumper.js
+++ b/services/dumper.js
@@ -35,7 +35,7 @@ function Dumper(config) {
       if (config.dbDialect.includes('postgres')) {
         dependencies.pg = '~6.1.0';
       } else if (config.dbDialect === 'mysql') {
-        dependencies.mysql2 = '~1.4.2';
+        dependencies.mysql2 = '~1.7.0';
       } else if (config.dbDialect === 'mssql') {
         dependencies.tedious = '^1.14.0';
       } else if (config.dbDialect === 'sqlite') {


### PR DESCRIPTION
See: https://github.com/ForestAdmin/lumber/pull/266

Adds the last version `1.7.0` in generated `package.json`. Without this additional change, [this issue](https://github.com/ForestAdmin/lumber/pull/266) would still be unresolved.

_I did not added a line in `CHANGELOG.md` since it's the same issue. It should have been in the same (merged) PR, we did not noticed it._