### PR TITLE
[+] Command Generate - Add  "Application port" parameter (`-p, --application-port`) to `lumber generate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Command Generate - Add  "Application port" parameter (`-p, --application-port`) to `lumber generate`.
+
 ### Fixed
 - Command Generate - Avoid foreignKey to conflict with relationship.
 - Command Generate - Fix creation of project containing whitespaces.

--- a/lumber-generate.js
+++ b/lumber-generate.js
@@ -10,6 +10,7 @@ const logger = require('./services/logger');
 program
   .description('Generate a backend application with an ORM/ODM configured.')
   .option('-c, --connection-url <connectionUrl>', 'Enter the database credentials with a connection URL')
+  .option('-p, --application-port <applicationPort>', 'Port of your admin backend app')
   .option('--no-db', 'Use Lumber without a database.')
   .parse(process.argv);
 

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -10,7 +10,7 @@ const FORMAT_PASSWORD = /^(?=\S*?[A-Z])(?=\S*?[a-z])((?=\S*?[0-9]))\S{8,}$/;
 
 async function Prompter(program, requests) {
   function isRequested(option) {
-    return requests.indexOf(option) > -1;
+    return requests.includes(option);
   }
 
   const envConfig = { db: program.db };
@@ -213,9 +213,8 @@ async function Prompter(program, requests) {
   }
 
   if (isRequested('appPort')) {
-    if (process.env.APPLICATION_PORT) {
-      envConfig.appPort = process.env.APPLICATION_PORT;
-    } else {
+    envConfig.applicationPort = process.env.APPLICATION_PORT || program.applicationPort;
+    if (!envConfig.applicationPort) {
       prompts.push({
         type: 'input',
         name: 'appPort',

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -213,7 +213,7 @@ async function Prompter(program, requests) {
   }
 
   if (isRequested('appPort')) {
-    envConfig.applicationPort = process.env.APPLICATION_PORT || program.applicationPort;
+    envConfig.applicationPort = program.applicationPort || process.env.APPLICATION_PORT;
     if (!envConfig.applicationPort) {
       prompts.push({
         type: 'input',

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -213,8 +213,9 @@ async function Prompter(program, requests) {
   }
 
   if (isRequested('appPort')) {
-    envConfig.applicationPort = program.applicationPort || process.env.APPLICATION_PORT;
-    if (!envConfig.applicationPort) {
+    // TODO: Remove APPLICATION_PORT environment variable usage in the future major Lumber version.
+    envConfig.appPort = program.applicationPort || process.env.APPLICATION_PORT;
+    if (!envConfig.appPort) {
       prompts.push({
         type: 'input',
         name: 'appPort',


### PR DESCRIPTION
> Lumber full options, step 1: Add  "Application port" parameter (`-p, --application-port`) to lumber generate 

 - Some refactor could have been done, but I want to focus on the actual topic.
 - However, I modified `requests.indexOf(option) > -1;` to `requests.includes(option)` since expressiveness in code is always better.  It does not require a separate commit IMO ; just like fixing a typo or a removing dead function.
 - I tested it _manually_ (see below) with: 
   - no env, no param
   - env, no param
   - no env, param
   - env, param (param is preferred over env)
 - To be unit tested, this code have to be refactored AFAIK (all code belongs to `Prompter` which is a long sync imperative function).