### PR TITLE
[+] Command Generate - Add  "SSL" parameter (`-S, --ssl`) to `lumber generate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Command Generate - Add  "Application port" parameter (`-p, --application-port`) to `lumber generate`.
 - Command Generate - Add  "Application host" parameter (`-H, --application-host`) to `lumber generate`.
+- Command Generate - Add  "SSL" parameter (`-S, --ssl`) to `lumber generate`.
 
 ### Fixed
 - Command Generate - Avoid foreignKey to conflict with relationship.

--- a/lumber-generate.js
+++ b/lumber-generate.js
@@ -10,6 +10,8 @@ const logger = require('./services/logger');
 program
   .description('Generate a backend application with an ORM/ODM configured.')
   .option('-c, --connection-url <connectionUrl>', 'Enter the database credentials with a connection URL')
+  // NOTICE: --ssl option is not a real boolean option since we do not want a breaking change.
+  .option('-S, --ssl <ssl>', 'Use SSL for database connection (true|false)')
   .option('-H, --application-host <applicationHost>', 'Hostname of your admin backend application')
   .option('-p, --application-port <applicationPort>', 'Port of your admin backend application')
   .option('--no-db', 'Use Lumber without a database.')

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -176,10 +176,10 @@ async function Prompter(program, requests) {
     const ssl = program.ssl || process.env.DATABASE_SSL;
     if (ssl) {
       try {
-        // NOTICE: Parse from string (e.g "true" or "false") to boolean. 
+        // NOTICE: Parse from string (e.g "true" or "false") to boolean.
         envConfig.ssl = JSON.parse(ssl.toLowerCase());
         if (typeof envConfig.ssl !== 'boolean') {
-          throw new Error;
+          throw new Error();
         }
       } catch (e) {
         logger.error(`Database SSL value must be either "true" or "false" ("${ssl}" given).`);

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -172,8 +172,19 @@ async function Prompter(program, requests) {
   }
 
   if (isRequested('ssl')) {
-    if (process.env.DATABASE_SSL) {
-      envConfig.ssl = JSON.parse(process.env.DATABASE_SSL.toLowerCase());
+    // TODO: Remove DATABASE_SSL environment variable usage in the future major Lumber version.
+    const ssl = program.ssl || process.env.DATABASE_SSL;
+    if (ssl) {
+      try {
+        // NOTICE: Parse from string (e.g "true" or "false") to boolean. 
+        envConfig.ssl = JSON.parse(ssl.toLowerCase());
+        if (typeof envConfig.ssl !== 'boolean') {
+          throw new Error;
+        }
+      } catch (e) {
+        logger.error(`Database SSL value must be either "true" or "false" ("${ssl}" given).`);
+        process.exit(1);
+      }
     } else {
       prompts.push({
         type: 'confirm',


### PR DESCRIPTION
See: https://github.com/ForestAdmin/lumber/pull/269 & https://github.com/ForestAdmin/lumber/pull/271. According to @arnaudbesnier suggestion, to avoid breaking changes, `--ssl` option is not a boolean, but a two value option ("true" or "false").

_I added a small fix. Previously, if the `DATABASE_SSL` had a wrong value, it crashed due to JSON parsing error. Now it just fails with a user friendly(?) message._