### PR TITLE
[*] Command Generate - Remove schema prompt with MongoDB connection URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Records Update - Fix `TINYINT` column update when declared as a `BOOLEAN` field in the ORM model.
 - Technical - Fix Github repository language.
 - Generate command - Generate field with type "TIME WITHOUT TIME ZONE".
+- Command Generate - Remove schema prompt with MongoDB connection URL.
 
 ## RELEASE 2.4.0 - 2019-09-20
 ### Changed

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -80,7 +80,7 @@ async function Prompter(program, requests) {
         name: 'dbSchema',
         message: 'What\'s the database schema? [optional]',
         description: 'Leave blank by default',
-        when: answers => answers.dbDialect !== 'sqlite' && answers.dbDialect !== 'mongodb',
+        when: answers => answers.dbDialect !== 'sqlite' && answers.dbDialect !== 'mongodb' && envConfig.dbDialect !== 'mongodb',
         default: (args) => {
           if (args.dbDialect === 'postgres') { return 'public'; }
           return '';


### PR DESCRIPTION
`lumber generate` asked for schema in this case:

```
lumber generate lol -c "mongodb://foo:bar@baz/test"
```