### PR TITLE
[*] Command Generate - Remove schema prompt for MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Technical - Fix dependencies in `package-lock.json`.
 - Command Generate - Fix projects generation based on MySQL connections. (Regression introduced in v2.4.1).
+- Command Generate - Remove schema prompt for MySQL.
 
 ## RELEASE 2.4.1 - 2019-10-11
 ### Added

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -106,8 +106,7 @@ async function Prompter(program, requests) {
         when: (answers) => {
           // NOTICE: MongoDB, MySQL and SQLite do not require a Schema.
           const skipDatabases = ['sqlite', 'mongodb', 'mysql'];
-          return !(skipDatabases.includes(answers.dbDialect)
-            || skipDatabases.includes(envConfig.dbDialect));
+          return !skipDatabases.includes(answers.dbDialect || envConfig.dbDialect);
         },
         default: (args) => {
           if (args.dbDialect === 'postgres') { return 'public'; }
@@ -286,10 +285,10 @@ async function Prompter(program, requests) {
           if (password) {
             if (FORMAT_PASSWORD.test(password)) { return true; }
             return '🔓  Your password security is too weak 🔓\n' +
-              ' Please make sure it contains at least:\n' +
-              '    > 8 characters\n' +
-              '    > Upper and lower case letters\n' +
-              '    > Numbers';
+            ' Please make sure it contains at least:\n' +
+            '    > 8 characters\n' +
+            '    > Upper and lower case letters\n' +
+            '    > Numbers';
           }
 
           return 'Your password cannot be blank.';

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -103,10 +103,11 @@ async function Prompter(program, requests) {
         name: 'dbSchema',
         message: 'What\'s the database schema? [optional]',
         description: 'Leave blank by default',
-        when: answers => {
+        when: (answers) => {
           // NOTICE: MongoDB, MySQL and SQLite do not require a Schema.
           const skipDatabases = ['sqlite', 'mongodb', 'mysql'];
-          return !(skipDatabases.includes(answers.dbDialect) || skipDatabases.includes(envConfig.dbDialect))
+          return !(skipDatabases.includes(answers.dbDialect)
+            || skipDatabases.includes(envConfig.dbDialect));
         },
         default: (args) => {
           if (args.dbDialect === 'postgres') { return 'public'; }
@@ -285,10 +286,10 @@ async function Prompter(program, requests) {
           if (password) {
             if (FORMAT_PASSWORD.test(password)) { return true; }
             return '🔓  Your password security is too weak 🔓\n' +
-            ' Please make sure it contains at least:\n' +
-            '    > 8 characters\n' +
-            '    > Upper and lower case letters\n' +
-            '    > Numbers';
+              ' Please make sure it contains at least:\n' +
+              '    > 8 characters\n' +
+              '    > Upper and lower case letters\n' +
+              '    > Numbers';
           }
 
           return 'Your password cannot be blank.';

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -103,7 +103,11 @@ async function Prompter(program, requests) {
         name: 'dbSchema',
         message: 'What\'s the database schema? [optional]',
         description: 'Leave blank by default',
-        when: answers => answers.dbDialect !== 'sqlite' && answers.dbDialect !== 'mongodb' && envConfig.dbDialect !== 'mongodb',
+        when: answers => {
+          // NOTICE: MongoDB, MySQL and SQLite do not require a Schema.
+          const skipDatabases = ['sqlite', 'mongodb', 'mysql'];
+          return !(skipDatabases.includes(answers.dbDialect) || skipDatabases.includes(envConfig.dbDialect))
+        },
         default: (args) => {
           if (args.dbDialect === 'postgres') { return 'public'; }
           return '';


### PR DESCRIPTION
`lumber generate` ask for schema for MySQL install. It could be removed since it's useless, MySQL does not use schema. Source: https://stackoverflow.com/questions/11618277/difference-between-schema-database-in-mysql & https://dev.mysql.com/doc/refman/8.0/en/glossary.html#glos_schema

_Issue detected during new features tests_
