### PR TITLE
[*] Technical - Change `no-multiple-empty-lines` ESLint rule. Disallow two and more consecutive empty lines

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,14 @@
 {
   "extends": "airbnb-base",
   "rules": {
-    "no-console": "off"
+    "no-console": "off",
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 1,
+        "maxBOF": 0,
+        "maxEOF": 0
+      }
+    ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - Generate command - Rename APP_NAME to APPLICATION_NAME for consistency. The old name remains supported.
+- Technical - Change `no-multiple-empty-lines` ESLint rule. Disallow two and more consecutive empty lines.
 
 ### Fixed
 - Technical - Fix dependencies in `package-lock.json`.


### PR DESCRIPTION
See: https://github.com/ForestAdmin/lumber/pull/281#discussion_r334547366