### PR TITLE
[*] Continuous Integration - Change `11.14` version of `node_js` to ` lts/*` in `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 language: node_js
 
-node_js: stable
+node_js: lts/*
 
 env:
   - NODE_ENV=travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: required
 
 language: node_js
 
-node_js:
-  - 11.14.0
+node_js: stable
 
 env:
   - NODE_ENV=travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Changed
 - Command Generate - Give models a unique pascal-cased name when generating sequelize model files.
-- Continuous Integration - Change `11.14` version of `node_js` to `stable` in `.travis.yml`.
+- Continuous Integration - Change `11.14` version of `node_js` to `lts/*` in `.travis.yml`.
 
 ### Fixed
 - MSSQL - Prevent potential bad database connection using upgrading an old version of `tedious` dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - Command Generate - Give models a unique pascal-cased name when generating sequelize model files.
+- Continuous Integration - Change `11.14` version of `node_js` to `stable` in `.travis.yml`.
 
 ### Fixed
 - MSSQL - Prevent potential bad database connection using upgrading an old version of `tedious` dependency.


### PR DESCRIPTION
11.14 is abandonned since July 2019: https://nodejs.org/en/about/releases/. We have to ensure CI use the current LTS version to build/test Lumber.