### PR TITLE
[*] Command Generate - Fix connection to MSSQL database with instance name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - MSSQL - Prevent potential bad database connection using upgrading an old version of `tedious` dependency.
 - Command Generate - Catch correctly authentication error on mongodb.
 - Command Generate - Catch correctly empty collections on mongodb.
+- Command Generate - Fix connection to database with instance name.
 
 ## RELEASE 2.5.0 - 2019-10-15
 ### Added

--- a/services/database.js
+++ b/services/database.js
@@ -77,10 +77,22 @@ function Database() {
       };
     }
 
+    let { dbConnectionUrl, dbHostname } = options;
+    if (databaseDialect === 'mssql' && dbConnectionUrl && dbConnectionUrl.includes('\\')) {
+      const [prefix, suffix] = dbConnectionUrl.split('\\');
+      const indexOfColon = suffix.indexOf(':');
+      dbConnectionUrl = `${prefix}${suffix.substring(indexOfColon)}`;
+      connectionOptionsSequelize.dialectOptions.instanceName = suffix.substring(0, indexOfColon);
+    } else if (databaseDialect === 'mssql' && options.dbHostname && options.dbHostname.includes('\\')) {
+      const [hostname, instanceName] = dbConnectionUrl.split('\\');
+      dbHostname = hostname;
+      connectionOptionsSequelize.dialectOptions.instanceName = instanceName;
+    }
+
     if (options.dbConnectionUrl) {
-      connection = new Sequelize(options.dbConnectionUrl, connectionOptionsSequelize);
+      connection = new Sequelize(dbConnectionUrl, connectionOptionsSequelize);
     } else {
-      connectionOptionsSequelize.host = options.dbHostname;
+      connectionOptionsSequelize.host = dbHostname;
       connectionOptionsSequelize.port = options.dbPort;
       connectionOptionsSequelize.dialect = databaseDialect;
 

--- a/services/database.js
+++ b/services/database.js
@@ -16,6 +16,10 @@ function Database() {
       .catch(error => handleAuthenticationError(error));
   }
 
+  function hasInstanceName(hostname) {
+    return hostname && hostname.includes('\\');
+  }
+
   this.connect = (options) => {
     const isSSL = options.dbSSL || options.ssl;
     let connection;
@@ -78,15 +82,17 @@ function Database() {
     }
 
     let { dbConnectionUrl, dbHostname } = options;
-    if (databaseDialect === 'mssql' && dbConnectionUrl && dbConnectionUrl.includes('\\')) {
-      const [prefix, suffix] = dbConnectionUrl.split('\\');
-      const indexOfColon = suffix.indexOf(':');
-      dbConnectionUrl = `${prefix}${suffix.substring(indexOfColon)}`;
-      connectionOptionsSequelize.dialectOptions.instanceName = suffix.substring(0, indexOfColon);
-    } else if (databaseDialect === 'mssql' && options.dbHostname && options.dbHostname.includes('\\')) {
-      const [hostname, instanceName] = dbConnectionUrl.split('\\');
-      dbHostname = hostname;
-      connectionOptionsSequelize.dialectOptions.instanceName = instanceName;
+    if (databaseDialect === 'mssql') {
+      if (hasInstanceName(dbConnectionUrl)) {
+        const [prefix, suffix] = dbConnectionUrl.split('\\');
+        const indexOfColon = suffix.indexOf(':');
+        dbConnectionUrl = `${prefix}${suffix.substring(indexOfColon)}`;
+        connectionOptionsSequelize.dialectOptions.instanceName = suffix.substring(0, indexOfColon);
+      } else if (hasInstanceName(options.dbHostname)) {
+        const [hostname, instanceName] = dbConnectionUrl.split('\\');
+        dbHostname = hostname;
+        connectionOptionsSequelize.dialectOptions.instanceName = instanceName;
+      }
     }
 
     if (options.dbConnectionUrl) {


### PR DESCRIPTION
I could not test it as I did not had any windows to test. But you can find the why here: https://github.com/sequelize/sequelize/issues/3097

If you have an host like: 'Test\SQLEXPRESS' sequelize won't handle it so you have to split it into server and instanceName 