### PR TITLE
[*] Technical - Fix repository in `package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Technical - Fix repository in `package.json`.
 
 ## RELEASE 2.5.2 - 2019-10-25
 ### Changed
@@ -15,6 +17,7 @@
 - NPM Publish - Do not send local environment variables on package publish.
 - NPM Publish - Remove Github templates from the published packages.
 - Command Generate - Fix MySQL connection failure without SSL.
+
 
 ## RELEASE 2.5.1 - 2019-10-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - NPM Publish - Remove Github templates from the published packages.
 - Command Generate - Fix MySQL connection failure without SSL.
 
-
 ## RELEASE 2.5.1 - 2019-10-18
 ### Changed
 - Command Generate - Give models a unique pascal-cased name when generating sequelize model files.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "Valentin Lamatte <valentinl@forestadmin.com>",
     "Arnaud Besnier <arnaudibesnier@gmail.com>"
   ],
+  "repository": "https://github.com/ForestAdmin/lumber",
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.4.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Valentin Lamatte <valentinl@forestadmin.com>",
     "Arnaud Besnier <arnaudibesnier@gmail.com>"
   ],
-  "repository": "https://github.com/ForestAdmin/lumber",
+  "repository": "github:ForestAdmin/lumber",
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
To avoid this warning:

```
➜  lumber git:(fix/lodash-version) ✗ npm i lodash@4.17.15 --save-exact
...
npm WARN lumber-cli@2.5.1 No repository field.
...
```