### PR TITLE
[*] Command Generate - Fix foreign key imports using connection URL with MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Command Generate - Fixed error when analyzing MongoDB views.
 - Security - Upgrade `lodash` dependencies to patch vulnerabilities.
 - Security - Upgrade `eslint` dependency to patch vulnerabilities.
+- Security - Use Sequelize replacements to avoid SQL injections.
+- Command Generate - Fix foreign key imports using connection URL with MySQL.
 
 ## RELEASE 2.5.1 - 2019-10-18
 ### Changed

--- a/services/database-analyzer.js
+++ b/services/database-analyzer.js
@@ -145,7 +145,7 @@ function DatabaseAnalyzer(databaseConnection, config, allowWarning) {
     const schema = {};
 
     queryInterface = databaseConnection.getQueryInterface();
-    tableForeignKeysAnalyzer = new TableForeignKeysAnalyzer(databaseConnection, config);
+    tableForeignKeysAnalyzer = new TableForeignKeysAnalyzer(databaseConnection);
     columnTypeGetter = new ColumnTypeGetter(databaseConnection, config.dbSchema || 'public', allowWarning);
 
     if (config.dbSchema) {

--- a/services/table-foreign-keys-analyzer.js
+++ b/services/table-foreign-keys-analyzer.js
@@ -1,4 +1,4 @@
-function TableForeignKeysAnalyzer(databaseConnection, config) {
+function TableForeignKeysAnalyzer(databaseConnection) {
   const queryInterface = databaseConnection.getQueryInterface();
 
   this.perform = async (table) => {

--- a/services/table-foreign-keys-analyzer.js
+++ b/services/table-foreign-keys-analyzer.js
@@ -60,7 +60,6 @@ function TableForeignKeysAnalyzer(databaseConnection) {
         break;
     }
 
-    console.log(replacements);
     return queryInterface.sequelize
       .query(query, { type: queryInterface.sequelize.QueryTypes.SELECT, replacements });
   };

--- a/services/table-foreign-keys-analyzer.js
+++ b/services/table-foreign-keys-analyzer.js
@@ -3,7 +3,7 @@ function TableForeignKeysAnalyzer(databaseConnection, config) {
 
   this.perform = async (table) => {
     let query = null;
-    let replacements = { table };
+    const replacements = { table };
 
     switch (queryInterface.sequelize.options.dialect) {
       case 'postgres':
@@ -32,9 +32,9 @@ function TableForeignKeysAnalyzer(databaseConnection, config) {
           FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
           WHERE TABLE_SCHEMA = :databaseName
             AND TABLE_NAME = :table;`;
-        // NOTICE: `config.dbName` may not exists when using connection URL. 
+        // NOTICE: `config.dbName` may not exists when using connection URL.
         //         Use `dbConnectionUrl` as a fallback.
-        replacements.databaseName = config.dbName || config.dbConnectionUrl.split("/").pop();
+        replacements.databaseName = config.dbName || config.dbConnectionUrl.split('/').pop();
         break;
       case 'mssql':
         query = `
@@ -56,7 +56,7 @@ function TableForeignKeysAnalyzer(databaseConnection, config) {
           WHERE fk.parent_object_id = (SELECT object_id FROM sys.tables WHERE name = :table)`;
         break;
       case 'sqlite':
-        query = `PRAGMA foreign_key_list(:table);`;
+        query = 'PRAGMA foreign_key_list(:table);';
         break;
       default:
         break;

--- a/services/table-foreign-keys-analyzer.js
+++ b/services/table-foreign-keys-analyzer.js
@@ -32,9 +32,7 @@ function TableForeignKeysAnalyzer(databaseConnection, config) {
           FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
           WHERE TABLE_SCHEMA = :databaseName
             AND TABLE_NAME = :table;`;
-        // NOTICE: `config.dbName` may not exists when using connection URL.
-        //         Use `dbConnectionUrl` as a fallback.
-        replacements.databaseName = config.dbName || config.dbConnectionUrl.split('/').pop();
+        replacements.databaseName = queryInterface.sequelize.config.database;
         break;
       case 'mssql':
         query = `


### PR DESCRIPTION
I do not usually like PR that fixes two issues, but in this case, fixing one has revealed one other: I would have not seen the foreign key error without Sequelize replacements. So the two fix are relatives to each other. So basically:
 - `field = '${foo}'` as been replaced by `field = :foo`+`{ replacements: { foo } }`
 - In case there is no `dbName`, `connectionUrl` is parsed for MySQL (which is the only one who requires its own database name when analyzing foreign keys).