### PR TITLE
[*] Command Generate - Fix MySQL connection failure without SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Security - Upgrade `eslint` dependency to patch vulnerabilities.
 - Security - Use Sequelize replacements to avoid SQL injections.
 - Command Generate - Fix foreign key imports using connection URL with MySQL.
+- Command Generate - Fix MySQL connection failure without SSL.
 
 ## RELEASE 2.5.1 - 2019-10-18
 ### Changed

--- a/services/database.js
+++ b/services/database.js
@@ -67,9 +67,15 @@ function Database() {
     // NOTICE: mysql2 does not accepts unwanted options anymore.
     //         See: https://github.com/sidorares/node-mysql2/pull/895
     if (databaseDialect === 'mysql') {
-      connectionOptionsSequelize.dialectOptions = {
-        ssl: { rejectUnauthorized: isSSL },
-      };
+      // NOTICE: Add SSL options only if the user selected SSL mode.
+      if (isSSL) {
+        // TODO: Lumber should accept certificate file (CRT) to work with SSL.
+        //       Since it requires to review onboarding, it is not implemented yet.
+        //       See: https://www.npmjs.com/package/mysql#ssl-options
+        connectionOptionsSequelize.dialectOptions = {
+          ssl: { rejectUnauthorized: isSSL },
+        };
+      }
     } else {
       connectionOptionsSequelize.dialectOptions = {
         ssl: isSSL,


### PR DESCRIPTION
MySQL onboarding with SSL is currently broken. AFAIK, we need to provide a certificate to make it work. BTW, MySQL connection **without SSL** seems broken too (using latest lumber versions): some users did have errors, so do I. 

An actual (temporary) solution might be to not add anything about SSL when the connection is without SSL, that's the purpose of this PR. 

@SteveBunlon To test the failure scenario, I recommend using the latest version LTS of Node with a fresh lumber install and try to connect with this kind of command: 
```
FOREST_URL="foo" lumber generate "bar" --connection-url "mysql://baz:foo@localhost:33061/bar" --ssl "false" --application-host "localhost" --application-port "3310"
```
Then to test it now works, try again with this branch.