### PR TITLE
[+] Field Types - Support `TIMESTAMP(n)`, `SMALLINT(n)` and `BIGINT(n)` column types (MySQL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Added
-- Field Types - Support `TIMESTAMP(n)`, `SMALLINT(n)`, `BIGINT(n)` and `BIT(1)` column types (MySQL)
+- Field Types - Support `TIMESTAMP(n)`, `SMALLINT(n)` and `BIGINT(n)` column types (MySQL)
 
 ## RELEASE 2.6.3 - 2019-11-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Field Types - Support `TIMESTAMP(n)`, `SMALLINT(n)`, `BIGINT(n)` and `BIT(1)` column types (MySQL)
 
 ## RELEASE 2.6.3 - 2019-11-04
 ### Fixed

--- a/services/column-type-getter.js
+++ b/services/column-type-getter.js
@@ -57,7 +57,6 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
 
     switch (type) {
       case 'BIT': // NOTICE: MSSQL type.
-      case 'BIT(1)': // NOTICE: MySQL type.
       case 'BOOLEAN':
         return 'BOOLEAN';
       case 'CHARACTER VARYING':

--- a/services/column-type-getter.js
+++ b/services/column-type-getter.js
@@ -105,8 +105,6 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
       case 'DATE':
       case 'DATETIME':
       case (type.match(/^TIMESTAMP.*/i) || {}).input:
-      case 'TIMESTAMP WITH TIME ZONE':
-      case 'TIMESTAMP WITHOUT TIME ZONE':
         return 'DATE';
       case 'TIME':
       case 'TIME WITHOUT TIME ZONE':

--- a/services/column-type-getter.js
+++ b/services/column-type-getter.js
@@ -57,6 +57,7 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
 
     switch (type) {
       case 'BIT': // NOTICE: MSSQL type.
+      case 'BIT(1)': // NOTICE: MySQL type.
       case 'BOOLEAN':
         return 'BOOLEAN';
       case 'CHARACTER VARYING':
@@ -82,14 +83,14 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
         return 'UUID';
       case 'JSONB':
         return 'JSONB';
-      case 'SMALLINT':
       case 'INTEGER':
       case 'SERIAL':
       case 'BIGSERIAL':
       case (type.match(/^INT.*/i) || {}).input:
+      case (type.match(/^SMALLINT.*/i) || {}).input:
       case (type.match(/^TINYINT.*/i) || {}).input:
         return 'INTEGER';
-      case 'BIGINT':
+      case (type.match(/^BIGINT.*/i) || {}).input:
         return 'BIGINT';
       case (type.match(/FLOAT.*/i) || {}).input:
         return 'FLOAT';
@@ -103,7 +104,7 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
         return 'DOUBLE';
       case 'DATE':
       case 'DATETIME':
-      case 'TIMESTAMP':
+      case (type.match(/^TIMESTAMP.*/i) || {}).input:
       case 'TIMESTAMP WITH TIME ZONE':
       case 'TIMESTAMP WITHOUT TIME ZONE':
         return 'DATE';


### PR DESCRIPTION
Some MySQL types are ignored on generation. Please test this carefully (it should not break existing types recognition).