### PR TITLE
[+] Connection String - we encode credentials when possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- ConnectionString - credentials are uri encoded when possible.
+
 ### Changed
 - Technical - Remove unused ENCRYPT env variable.
 

--- a/services/connection-strings.js
+++ b/services/connection-strings.js
@@ -1,0 +1,35 @@
+const { ConnectionStringError } = require('../utils/errors');
+
+const HOSTS_RX = /(.*?):\/\/(?: (?:[^:]*) (?: : ([^@]*) )? @ )?([^/?]*)(?:\/|)(.*)/;
+
+const encodeConnectionString = (uri) => {
+  const cap = uri.match(HOSTS_RX);
+  if (!cap) {
+    throw new ConnectionStringError.InvalidConnectionString('Can\'t parse connection string');
+  }
+  const [, protocol, , userPasswordHostPort, dbQuery] = cap;
+
+  if (dbQuery.split('?')[0].indexOf('@') !== -1) {
+    throw new ConnectionStringError.InvalidConnectionString('Unescaped \'/\' slash in user/host or db/query section');
+  }
+
+  const authorityParts = userPasswordHostPort.split('@');
+  if (authorityParts.length > 2) {
+    throw new ConnectionStringError.InvalidConnectionString('Unescaped \'@\' in user/host section');
+  }
+
+  const auth = {};
+  if (authorityParts.length > 1) {
+    const authParts = authorityParts.shift().split(':');
+    if (authParts.length > 2) {
+      throw new ConnectionStringError.InvalidConnectionString('Unescaped \':\' in user/host section');
+    }
+    auth.username = encodeURIComponent(authParts[0]);
+    auth.password = encodeURIComponent(authParts[1] || null);
+  }
+
+  const hostPort = authorityParts.shift();
+  return `${protocol}://${auth.username ? `${auth.username}${(auth.password ? `:${auth.password}@` : '')}` : ''}${hostPort}${dbQuery ? `/${dbQuery}` : ''}`;
+};
+
+module.exports = { encodeConnectionString };

--- a/services/prompter.js
+++ b/services/prompter.js
@@ -6,6 +6,7 @@ const chalk = require('chalk');
 const logger = require('./logger');
 const eventSender = require('./event-sender');
 const DirectoryExistenceChecker = require('./directory-existence-checker');
+const { encodeConnectionString } = require('./connection-strings');
 
 const FORMAT_PASSWORD = /^(?=\S*?[A-Z])(?=\S*?[a-z])((?=\S*?[0-9]))\S{8,}$/;
 
@@ -45,7 +46,13 @@ async function Prompter(program, requests) {
   }
 
   if (isRequested('dbConnectionUrl')) {
-    envConfig.dbConnectionUrl = program.connectionUrl || process.env.DATABASE_URL;
+    const connectionString = program.connectionUrl || process.env.DATABASE_URL;
+    try {
+      envConfig.dbConnectionUrl = encodeConnectionString(connectionString);
+    } catch (error) {
+      logger.error(error);
+      process.exit(1);
+    }
 
     try {
       [, envConfig.dbDialect] = envConfig.dbConnectionUrl.match(/(.*):\/\//);

--- a/test/services/connection-strings.js
+++ b/test/services/connection-strings.js
@@ -1,0 +1,57 @@
+const { expect } = require('chai');
+
+const { ConnectionStringError } = require('../../utils/errors');
+
+const {
+  encodeConnectionString,
+} = require('../../services/connection-strings');
+
+describe('Connection Strings', () => {
+  it('should return unchanged connection string', () => {
+    const inputs = [
+      'mongodb://localhost:27017',
+      'mongodb://forest:secret@localhost:27017/requests?authSource=admin',
+      'mongodb://forest:secret@localhost:27017/dimdime?authSource=admin',
+      'mssql://azureuser:forest2019@mysqlserver1989.database.windows.net:1433/mssql-test-nov',
+    ];
+    inputs.forEach(input => expect(encodeConnectionString(input)).to.equals(input));
+  });
+
+  it('should return a connection string with encoded username and password', () => {
+    const input = 'mongodb://supe&ru=ser:=superpass&word@localhost:27017/base?dd=ee';
+    const expected = 'mongodb://supe%26ru%3Dser:%3Dsuperpass%26word@localhost:27017/base?dd=ee';
+    expect(encodeConnectionString(input)).to.equals(expected);
+  });
+
+  it('should throw "Can\'t parse connection string"', () => {
+    const input = 'bad_uri';
+    const malformedInputEncoding = () => {
+      encodeConnectionString(input);
+    };
+    expect(malformedInputEncoding).to.throw(ConnectionStringError.InvalidConnectionString, 'Can\'t parse connection string');
+  });
+
+  it('should throw "Unescaped \'@\' in authority section"', () => {
+    const input = 'mongodb://supe@ruser:superpass@word@localhost:27017/base?dd=ee';
+    const malformedInputEncoding = () => {
+      encodeConnectionString(input);
+    };
+    expect(malformedInputEncoding).to.throw(ConnectionStringError.InvalidConnectionString, 'Unescaped \'@\' in user/host section');
+  });
+
+  it('should throw "InvalidConnectionString: Unescaped \':\' in authority section"', () => {
+    const input = 'mongodb://supe:ruser:superpass:word@localhost:27017/base?dd=ee';
+    const malformedInputEncoding = () => {
+      encodeConnectionString(input);
+    };
+    expect(malformedInputEncoding).to.throw(ConnectionStringError.InvalidConnectionString, 'Unescaped \':\' in user/host section');
+  });
+
+  it('should return unchanged connection string with "/"', () => {
+    const input = 'mongodb://supe:ruser:supe/rpass:word@localhost:27017/base?dd=ee';
+    const malformedInputEncoding = () => {
+      encodeConnectionString(input);
+    };
+    expect(malformedInputEncoding).to.throw(ConnectionStringError.InvalidConnectionString, 'Unescaped \'/\' slash in user/host or db/query section');
+  });
+});

--- a/utils/errors.js
+++ b/utils/errors.js
@@ -12,3 +12,12 @@ function createLumberError(name) {
 exports.DatabaseAnalyzerError = {
   EmptyDatabase: createLumberError('EmptyDatabase'),
 };
+
+class InvalidConnectionString extends Error {
+  constructor(message) {
+    super();
+    this.message = message;
+  }
+}
+
+exports.ConnectionStringError = { InvalidConnectionString };


### PR DESCRIPTION
Please challenge this PR. It seems useless to me after doing it. (Am I tired?)

Given a connection string having `['@', '/', ':', '?']` in credentials part
When lumber generates
Then an error is thrown

Given a connection string with any special character except`['@', '/', ':', '?']` inside credentials part
When lumber generates
Then user and password must be url encoded.

But it seems customers have problem with `['@', '/', ':', '?']` characters only. These should be encoded.

Other special characters `=€-°'$&+,;()[]|~%*<>#^£^¨ù` can already be successfully used in user and password connection string. (mongo only)

1: People having ['@', '/', ':', '?']` in its credentials must encode them. (this PR says that)
2: What about people already encoding their values? Encoding twice will fail the auth.

**1+2 = people with `['@', '/', ':', '?']` in credentials can not auth at all.**