### PR TITLE
[+] Node version - Define supported node versions (10 and 12) in `package.json`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: required
 
 language: node_js
 
-node_js: lts/*
+node_js: 
+  - lts/*
+  - 10
 
 env:
   - NODE_ENV=travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Node version - Define supported node versions (10 and 12) in `package.json`.
+
 ### Changed
 - Technical - Remove unused ENCRYPT env variable.
 - Security - Prevent remote environments creation with HTTP protocol.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "bin": {
     "lumber": "lumber.js"
   },
+  "engines": {
+    "node": "^10 || ^12"
+  },
   "author": "Sandro Munda",
   "contributors": [
     "Vincent Molinié <vincentm@forestadmin.com>",


### PR DESCRIPTION
We support latests 10 and 12. 14 is not ready yet, 8 is dropped in one month.

<img width="772" alt="Capture d’écran 2019-11-18 à 10 58 36" src="https://user-images.githubusercontent.com/1575946/69046560-8de01100-09f9-11ea-951e-08cd34ba06cf.png">
