### PR TITLE
[*] Command Generate - Rename model `sessions` to `session` to avoid conflict with forest routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 - Technical - Use Yarn instead of NPM in the CI.
 - Technical - Rename `.env.example` file.
 - Technical - Upgrade ESLint rules.
+- Command Generate - Camelize the table name to have better model name.
 
 ### Fixed
 - MySQL - Handle BIT(1) boolean columns and handle the buffer<01> value returned on join queries.
+- Command Generate - Rename model `sessions` to `session` to avoid conflict with forest routes.
 
 ## RELEASE 3.0.1 - 2019-11-20
 ### Fixed

--- a/services/analyze-mongo-hasmany.js
+++ b/services/analyze-mongo-hasmany.js
@@ -60,7 +60,7 @@ const detectHasMany = (databaseConnection, fields, collectionName) => {
 const applyHasMany = (fields, references) =>
   references.forEach((reference) => {
     const field = _.find(fields, { name: reference.from.fieldName });
-    field.ref = reference.to.collectionName;
+    field.refTable = reference.to.collectionName;
     field.hasMany = true;
   });
 

--- a/services/analyze-mongo-references.js
+++ b/services/analyze-mongo-references.js
@@ -12,7 +12,7 @@ const pickSampleValues = (databaseConnection, collectionName, field) =>
       { $project: { _id: false, value: `$${field.name}` } },
     ])
     .toArray()
-    .then(samples => _.map(samples, 'value'));
+    .then((samples) => _.map(samples, 'value'));
 
 const findCollectionMatchingSamples = async (databaseConnection, collectionName, samples) =>
   P.mapSeries(databaseConnection.collections(), async (collection) => {
@@ -21,7 +21,7 @@ const findCollectionMatchingSamples = async (databaseConnection, collectionName,
       return collection.s.namespace.collection;
     }
     return null;
-  }).then(matches => _.filter(matches, match => match));
+  }).then((matches) => _.filter(matches, (match) => match));
 
 const buildReference = (collectionName, referencedCollection, field) => {
   if (referencedCollection) {
@@ -46,16 +46,16 @@ const filterReferenceCollection = (collectionName, field, referencedCollections)
 
 const detectReference = (databaseConnection, field, collectionName) =>
   pickSampleValues(databaseConnection, collectionName, field)
-    .then(samples => findCollectionMatchingSamples(databaseConnection, collectionName, samples))
-    .then(matches => filterReferenceCollection(collectionName, field, matches))
-    .then(referencedCollection => buildReference(collectionName, referencedCollection, field));
+    .then((samples) => findCollectionMatchingSamples(databaseConnection, collectionName, samples))
+    .then((matches) => filterReferenceCollection(collectionName, field, matches))
+    .then((referencedCollection) => buildReference(collectionName, referencedCollection, field));
 
 const detectReferences = (databaseConnection, fields, collectionName) => {
-  const objectIdFields = fields.filter(field => field.type === OBJECT_ID);
+  const objectIdFields = fields.filter((field) => field.type === OBJECT_ID);
   return P.mapSeries(
     objectIdFields,
-    objectIdField => detectReference(databaseConnection, objectIdField, collectionName),
-  ).then(references => references.filter(reference => reference));
+    (objectIdField) => detectReference(databaseConnection, objectIdField, collectionName),
+  ).then((references) => references.filter((reference) => reference));
 };
 
 const applyReferences = (fields, references) =>

--- a/services/analyze-mongo-references.js
+++ b/services/analyze-mongo-references.js
@@ -12,7 +12,7 @@ const pickSampleValues = (databaseConnection, collectionName, field) =>
       { $project: { _id: false, value: `$${field.name}` } },
     ])
     .toArray()
-    .then((samples) => _.map(samples, 'value'));
+    .then(samples => _.map(samples, 'value'));
 
 const findCollectionMatchingSamples = async (databaseConnection, collectionName, samples) =>
   P.mapSeries(databaseConnection.collections(), async (collection) => {
@@ -21,7 +21,7 @@ const findCollectionMatchingSamples = async (databaseConnection, collectionName,
       return collection.s.namespace.collection;
     }
     return null;
-  }).then((matches) => _.filter(matches, (match) => match));
+  }).then(matches => _.filter(matches, match => match));
 
 const buildReference = (collectionName, referencedCollection, field) => {
   if (referencedCollection) {
@@ -46,22 +46,22 @@ const filterReferenceCollection = (collectionName, field, referencedCollections)
 
 const detectReference = (databaseConnection, field, collectionName) =>
   pickSampleValues(databaseConnection, collectionName, field)
-    .then((samples) => findCollectionMatchingSamples(databaseConnection, collectionName, samples))
-    .then((matches) => filterReferenceCollection(collectionName, field, matches))
-    .then((referencedCollection) => buildReference(collectionName, referencedCollection, field));
+    .then(samples => findCollectionMatchingSamples(databaseConnection, collectionName, samples))
+    .then(matches => filterReferenceCollection(collectionName, field, matches))
+    .then(referencedCollection => buildReference(collectionName, referencedCollection, field));
 
 const detectReferences = (databaseConnection, fields, collectionName) => {
-  const objectIdFields = fields.filter((field) => field.type === OBJECT_ID);
+  const objectIdFields = fields.filter(field => field.type === OBJECT_ID);
   return P.mapSeries(
     objectIdFields,
-    (objectIdField) => detectReference(databaseConnection, objectIdField, collectionName),
-  ).then((references) => references.filter((reference) => reference));
+    objectIdField => detectReference(databaseConnection, objectIdField, collectionName),
+  ).then(references => references.filter(reference => reference));
 };
 
 const applyReferences = (fields, references) =>
   references.forEach((reference) => {
     const field = _.find(fields, { name: reference.from.fieldName });
-    field.ref = reference.to.collectionName;
+    field.refTable = reference.to.collectionName;
   });
 
 module.exports = { detectReferences, applyReferences };

--- a/services/analyze-sequelize-tables.js
+++ b/services/analyze-sequelize-tables.js
@@ -10,8 +10,8 @@ let tableForeignKeysAnalyzer;
 let columnTypeGetter;
 
 function isUnderscored(fields) {
-  return fields.every(field => field.nameColumn === _.snakeCase(field.nameColumn))
-    && fields.some(field => field.nameColumn.includes('_'));
+  return fields.every((field) => field.nameColumn === _.snakeCase(field.nameColumn))
+    && fields.some((field) => field.nameColumn.includes('_'));
 }
 
 function analyzeFields(table, config) {
@@ -19,7 +19,7 @@ function analyzeFields(table, config) {
 }
 
 async function analyzePrimaryKeys(schema) {
-  return Object.keys(schema).filter(column => schema[column].primaryKey);
+  return Object.keys(schema).filter((column) => schema[column].primaryKey);
 }
 
 async function showAllTables(databaseConnection, schema) {
@@ -42,7 +42,7 @@ async function showAllTables(databaseConnection, schema) {
     'SELECT table_name as table_name FROM information_schema.tables WHERE table_schema = ? AND table_type LIKE \'%TABLE\' AND table_name != \'spatial_ref_sys\'',
     { type: queryInterface.sequelize.QueryTypes.SELECT, replacements: [realSchema] },
   )
-    .then(results => results.map(table => table.table_name));
+    .then((results) => results.map((table) => table.table_name));
 }
 
 function hasTimestamps(fields) {
@@ -75,14 +75,14 @@ function formatAliasName(columnName) {
 
 // NOTICE: Look for the id column in both fields and primary keys.
 function hasIdColumn(fields, primaryKeys) {
-  return fields.some(field => field.name === 'id' || field.nameColumn === 'id')
+  return fields.some((field) => field.name === 'id' || field.nameColumn === 'id')
     || _.includes(primaryKeys, 'id');
 }
 
 function analyzeTable(table, config) {
   return P
     .resolve(analyzeFields(table, config))
-    .then(schema => P.all([
+    .then((schema) => P.all([
       schema,
       tableForeignKeysAnalyzer.perform(table),
       analyzePrimaryKeys(schema),
@@ -164,7 +164,7 @@ async function analyzeSequelizeTables(databaseConnection, config, allowWarning) 
         'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?;',
         { type: queryInterface.sequelize.QueryTypes.SELECT, replacements: [config.dbSchema] },
       )
-      .then(result => !!result.length);
+      .then((result) => !!result.length);
 
     if (!schemaExists) {
       const message = 'This schema does not exists.';

--- a/services/analyze-sequelize-tables.js
+++ b/services/analyze-sequelize-tables.js
@@ -10,8 +10,8 @@ let tableForeignKeysAnalyzer;
 let columnTypeGetter;
 
 function isUnderscored(fields) {
-  return fields.every((field) => field.nameColumn === _.snakeCase(field.nameColumn))
-    && fields.some((field) => field.nameColumn.includes('_'));
+  return fields.every(field => field.nameColumn === _.snakeCase(field.nameColumn))
+    && fields.some(field => field.nameColumn.includes('_'));
 }
 
 function analyzeFields(table, config) {
@@ -19,7 +19,7 @@ function analyzeFields(table, config) {
 }
 
 async function analyzePrimaryKeys(schema) {
-  return Object.keys(schema).filter((column) => schema[column].primaryKey);
+  return Object.keys(schema).filter(column => schema[column].primaryKey);
 }
 
 async function showAllTables(databaseConnection, schema) {
@@ -42,7 +42,7 @@ async function showAllTables(databaseConnection, schema) {
     'SELECT table_name as table_name FROM information_schema.tables WHERE table_schema = ? AND table_type LIKE \'%TABLE\' AND table_name != \'spatial_ref_sys\'',
     { type: queryInterface.sequelize.QueryTypes.SELECT, replacements: [realSchema] },
   )
-    .then((results) => results.map((table) => table.table_name));
+    .then(results => results.map(table => table.table_name));
 }
 
 function hasTimestamps(fields) {
@@ -75,14 +75,14 @@ function formatAliasName(columnName) {
 
 // NOTICE: Look for the id column in both fields and primary keys.
 function hasIdColumn(fields, primaryKeys) {
-  return fields.some((field) => field.name === 'id' || field.nameColumn === 'id')
+  return fields.some(field => field.name === 'id' || field.nameColumn === 'id')
     || _.includes(primaryKeys, 'id');
 }
 
 function analyzeTable(table, config) {
   return P
     .resolve(analyzeFields(table, config))
-    .then((schema) => P.all([
+    .then(schema => P.all([
       schema,
       tableForeignKeysAnalyzer.perform(table),
       analyzePrimaryKeys(schema),
@@ -101,7 +101,7 @@ function analyzeTable(table, config) {
           && foreignKey.column_name
           && !columnInfo.primaryKey) {
           const reference = {
-            ref: foreignKey.foreign_table_name,
+            refTable: foreignKey.foreign_table_name,
             foreignKey: foreignKey.column_name,
             foreignKeyName: _.camelCase(foreignKey.column_name),
             as: formatAliasName(foreignKey.column_name),
@@ -164,7 +164,7 @@ async function analyzeSequelizeTables(databaseConnection, config, allowWarning) 
         'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?;',
         { type: queryInterface.sequelize.QueryTypes.SELECT, replacements: [config.dbSchema] },
       )
-      .then((result) => !!result.length);
+      .then(result => !!result.length);
 
     if (!schemaExists) {
       const message = 'This schema does not exists.';

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -147,7 +147,12 @@ function Dumper(config) {
       const expectedConventionalColumnName = underscored ? _.snakeCase(field.name) : field.name;
       const nameColumnUnconventional = field.nameColumn !== expectedConventionalColumnName
         || (underscored && /[1-9]/g.test(field.name));
-      return { ...field, nameColumnUnconventional };
+      const ref = field.refTable ? getModelName(field.refTable) : undefined;
+      return {
+        ...field,
+        nameColumnUnconventional,
+        ref,
+      };
     });
 
     const referencesDefinition = references.map((reference) => {

--- a/templates/app/forest/collection.txt
+++ b/templates/app/forest/collection.txt
@@ -5,7 +5,7 @@ const { collection } = require('forest-express-<% if (dbDialect === 'mongodb') {
 // - Smart fields: https://docs.forestadmin.com/documentation/reference-guide/fields/create-and-manage-smart-fields
 // - Smart relationships: https://docs.forestadmin.com/documentation/reference-guide/relationships/create-a-smart-relationship
 // - Smart segments: https://docs.forestadmin.com/documentation/reference-guide/segments/smart-segments
-collection('<%= table %>', {
+collection('<%= modelName %>', {
     actions: [],
     fields: [],
     segments: [],

--- a/templates/app/models/sequelize-model.hbs
+++ b/templates/app/models/sequelize-model.hbs
@@ -4,7 +4,7 @@ module.exports = (sequelize, DataTypes) => {
   const { Sequelize } = sequelize;
   // This section contains the fields of your model, mapped to your table's columns.
   // Learn more here: https://docs.forestadmin.com/documentation/v/v5/reference-guide/models/enrich-your-models#declaring-a-new-field-in-a-model
-  const {{modelName}} = sequelize.define('{{table}}', {
+  const {{modelNameVariable}} = sequelize.define('{{modelName}}', {
 {{#each fields as |field|}}
     {{field.name}}: {
       type: DataTypes.{{{field.type}}},{{#if field.nameColumnUnconventional}}
@@ -19,11 +19,11 @@ module.exports = (sequelize, DataTypes) => {
     timestamps: false,{{/unless}}{{#if schema}}
     schema: process.env.DATABASE_SCHEMA,{{/if}}
   });
-{{#if noId}}  {{modelName}}.removeAttribute('id');{{/if}}
+{{#if noId}}  {{modelNameVariable}}.removeAttribute('id');{{/if}}
   // This section contains the relationships for this model. See: https://docs.forestadmin.com/documentation/v/v5/reference-guide/relationships#adding-relationships.
-  {{modelName}}.associate = (models) => {
+  {{modelNameVariable}}.associate = (models) => {
     {{#each references as |reference|}}
-    {{../modelName}}.belongsTo(models.{{reference.ref}}, {
+    {{../modelNameVariable}}.belongsTo(models.{{reference.ref}}, {
       foreignKey: {
         name: '{{reference.foreignKeyName}}',{{#if reference.foreignKeyColumnUnconventional}}
         field: '{{reference.foreignKey}}',{{/if}}
@@ -37,5 +37,5 @@ module.exports = (sequelize, DataTypes) => {
     {{/each}}
   };
 
-  return {{modelName}};
+  return {{modelNameVariable}};
 };

--- a/test/expected/mongo/db-analysis-output/hasmany.json
+++ b/test/expected/mongo/db-analysis-output/hasmany.json
@@ -4,12 +4,12 @@
       {
         "hasMany": true,
         "name": "actors",
-        "ref": "persons",
+        "refTable": "persons",
         "type": "[mongoose.Schema.Types.ObjectId]"
       },
       {
         "name": "author",
-        "ref": "persons",
+        "refTable": "persons",
         "type": "mongoose.Schema.Types.ObjectId"
       },
       {

--- a/test/expected/mongo/db-analysis-output/many-nulls.json
+++ b/test/expected/mongo/db-analysis-output/many-nulls.json
@@ -3,7 +3,7 @@
     "fields": [
       {
         "name": "author",
-        "ref": "persons",
+        "refTable": "persons",
         "type": "mongoose.Schema.Types.ObjectId"
       },
       {

--- a/test/expected/mongo/db-analysis-output/many-objectid-fields.json
+++ b/test/expected/mongo/db-analysis-output/many-objectid-fields.json
@@ -3,12 +3,12 @@
     "fields": [
       {
         "name": "author",
-        "ref": "persons",
+        "refTable": "persons",
         "type": "mongoose.Schema.Types.ObjectId"
       },
       {
         "name": "bestActor",
-        "ref": "persons",
+        "refTable": "persons",
         "type": "mongoose.Schema.Types.ObjectId"
       },
       {
@@ -28,12 +28,12 @@
     "fields": [
       {
         "name": "cousin",
-        "ref": "persons",
+        "refTable": "persons",
         "type": "mongoose.Schema.Types.ObjectId"
       },
       {
         "name": "dad",
-        "ref": "persons",
+        "refTable": "persons",
         "type": "mongoose.Schema.Types.ObjectId"
       },
       {
@@ -42,12 +42,12 @@
       },
       {
         "name": "preferredFilm",
-        "ref": "films",
+        "refTable": "films",
         "type": "mongoose.Schema.Types.ObjectId"
       },
       {
         "name": "son",
-        "ref": "persons",
+        "refTable": "persons",
         "type": "mongoose.Schema.Types.ObjectId"
       }
     ],

--- a/test/expected/mongo/db-analysis-output/simple.json
+++ b/test/expected/mongo/db-analysis-output/simple.json
@@ -3,7 +3,7 @@
     "fields": [
       {
         "name": "author",
-        "ref": "persons",
+        "refTable": "persons",
         "type": "mongoose.Schema.Types.ObjectId"
       },
       {

--- a/test/expected/mysql/addresses.json
+++ b/test/expected/mysql/addresses.json
@@ -20,7 +20,7 @@
       "as": "customer",
       "foreignKey": "customer_id",
       "foreignKeyName": "customerId",
-      "ref": "customers"
+      "refTable": "customers"
     }
   ],
   "primaryKeys": [

--- a/test/expected/postgres/addresses.json
+++ b/test/expected/postgres/addresses.json
@@ -17,7 +17,7 @@
   ],
   "references": [
     {
-      "ref": "customers",
+      "refTable": "customers",
       "foreignKey": "customer_id",
       "foreignKeyName": "customerId",
       "as": "customer"

--- a/test/expected/renderings-sequelize.json
+++ b/test/expected/renderings-sequelize.json
@@ -51,26 +51,26 @@
     ],
     "references": [
       {
-        "ref": "environments",
+        "refTable": "environments",
         "foreignKey": "environmentId",
         "foreignKeyName": "environmentIdUnconventionnal",
         "as": "environment"
       },
       {
-        "ref": "teams",
+        "refTable": "teams",
         "foreignKey": "teamId",
         "foreignKeyName": "teamId",
         "as": "team"
       },
       {
-        "ref": "otherWithTarget",
+        "refTable": "otherWithTarget",
         "foreignKey": "other",
         "foreignKeyName": "other",
         "targetKey": "otherId",
         "as": "team2"
       },
       {
-        "ref": "film",
+        "refTable": "film",
         "foreignKey": "filmKeyName",
         "foreignKeyName": "filmKeyName",
         "targetKey": "film_target_key",


### PR DESCRIPTION
# How to reproduce
Create a model named `sessions`.
Create a new project with lumber.
Try to login to your liana.

# What has been done ?
I just rename the model to `session` without the s to avoid conflict with the `POST /forest/sessions`