### PR TITLE
[*] Technical - Fix linted deleted files issue

### DIFF
--- a/.eslint-bin/pre-commit-hook.js
+++ b/.eslint-bin/pre-commit-hook.js
@@ -12,7 +12,7 @@ function getFilesModified(callback) {
     }
 
     listFilesModified = status.files
-      .filter(change => change.index !== 'D')
+      .filter((change) => change.index !== 'D')
       .map((file) => file.path)
       .filter((file) => file.endsWith('.js'));
 

--- a/.eslint-bin/pre-commit-hook.js
+++ b/.eslint-bin/pre-commit-hook.js
@@ -12,6 +12,7 @@ function getFilesModified(callback) {
     }
 
     listFilesModified = status.files
+      .filter(change => change.index !== 'D')
       .map((file) => file.path)
       .filter((file) => file.endsWith('.js'));
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - MySQL - Handle BIT(1) boolean columns and handle the buffer<01> value returned on join queries.
 - Technical - Fix unexpected test errors while running in the CI.
 - Technical - Fix database connection pool issue on tests.
-- Technical - Fix lint on deleted files issue.
+- Technical - Fix pre-commit hook when deleting a file.
 - Custom Domain - Fix the CORS middleware to take CORS env variables into account.
 
 ## RELEASE 3.0.1 - 2019-11-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - MySQL - Handle BIT(1) boolean columns and handle the buffer<01> value returned on join queries.
 - Technical - Fix unexpected test errors while running in the CI.
 - Technical - Fix database connection pool issue on tests. 
+- Technical - Fix lint on deleted files issue.
 
 ## RELEASE 3.0.1 - 2019-11-20
 ### Fixed


### PR DESCRIPTION
This PR allows committing a file deletion.
Before that, `pre-commit-hook` linter was adding the deleted files in the `listModifiedFiles`

Here is an example of the issue. After deleting a file, the linter wanted to lint it.
<img width="707" alt="Screenshot 2019-12-10 at 15 41 58" src="https://user-images.githubusercontent.com/3200482/70539201-a14b4b80-1b63-11ea-8055-8d68123f5657.png">
