### PR TITLE
[*] Templates - Fix indentation (from 4 to 2 spaces) in collection files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Custom Domain - Fix the CORS middleware to take CORS env variables into account.
 - Technical - Fix bad database connection url for some PostgreSQL tests.
 - Fields Detection - Fix MySQL and MSSQL boolean columns default values generated in models files.
+- Templates - Fix indentation (from 4 to 2 spaces) in collection files.
 
 ## RELEASE 3.0.1 - 2019-11-20
 ### Fixed

--- a/templates/app/forest/collection.txt
+++ b/templates/app/forest/collection.txt
@@ -6,7 +6,7 @@ const { collection } = require('forest-express-<% if (dbDialect === 'mongodb') {
 // - Smart relationships: https://docs.forestadmin.com/documentation/reference-guide/relationships/create-a-smart-relationship
 // - Smart segments: https://docs.forestadmin.com/documentation/reference-guide/segments/smart-segments
 collection('<%= table %>', {
-    actions: [],
-    fields: [],
-    segments: [],
+  actions: [],
+  fields: [],
+  segments: [],
 });


### PR DESCRIPTION
I saw this when I was editing a collection file in lumber, VS code switched to "4 spaces". All other files are indented with 2 spaces, so I just fixed it. No trello card, since it took me 2 minutes, and it's a self-initiative.