### PR TITLE
[*] Command Generate - Fix conflict between aliases and foreignKey names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
 - Fields Detection - Fix MySQL and MSSQL boolean columns default values generated in models files.
 - Command Generate - Fix indentation (from 4 to 2 spaces) in collection files.
 - Command Generate - Remove an unused dependency in "forestadmin" middleware.
-- Command Generate - Fix conflict between aliases and foreignKey names.
 
 ## RELEASE 3.0.1 - 2019-11-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fields Detection - Fix MySQL and MSSQL boolean columns default values generated in models files.
 - Command Generate - Fix indentation (from 4 to 2 spaces) in collection files.
 - Command Generate - Remove an unused dependency in "forestadmin" middleware.
+- Command Generate - Fix conflict between aliases and foreignKey names.
 
 ## RELEASE 3.0.1 - 2019-11-20
 ### Fixed

--- a/services/analyzer/sequelize-tables-analyzer.js
+++ b/services/analyzer/sequelize-tables-analyzer.js
@@ -99,7 +99,7 @@ function checkUnicity(primaryKeys, uniqueIndexes, columnName) {
 function createReference(tableName, association, foreignKey, manyToManyForeignKey) {
   const reference = {
     foreignKey: foreignKey.columnName,
-    foreignKeyName: _.camelCase(foreignKey.columnName),
+    foreignKeyName: `${_.camelCase(foreignKey.columnName)}Key`,
     association,
   };
 
@@ -119,12 +119,6 @@ function createReference(tableName, association, foreignKey, manyToManyForeignKe
       : `${formatAliasName(reference.foreignKeyName)}_`;
 
     reference.as = _.camelCase(formater(`${prefix}${foreignKey.tableName}`));
-  }
-
-  // NOTICE: If the foreign key name and alias are the same, Sequelize will crash, we need
-  //         to handle this specific scenario generating a different foreign key name.
-  if (reference.foreignKeyName && reference.foreignKeyName === reference.as) {
-    reference.foreignKeyName = `${reference.foreignKeyName}Key`;
   }
 
   if (foreignKey.foreignColumnName !== 'id') {

--- a/services/analyzer/sequelize-tables-analyzer.js
+++ b/services/analyzer/sequelize-tables-analyzer.js
@@ -114,9 +114,9 @@ function createReference(tableName, association, foreignKey, manyToManyForeignKe
     reference.ref = foreignKey.tableName;
 
     const formater = association === ASSOCIATION_TYPE_HAS_MANY ? plural : singular;
-    const prefix = (singular(tableName) === formatAliasName(reference.foreignKeyName))
+    const prefix = (singular(tableName) === formatAliasName(_.camelCase(foreignKey.columnName)))
       ? ''
-      : `${formatAliasName(reference.foreignKeyName)}_`;
+      : `${formatAliasName(_.camelCase(foreignKey.columnName))}_`;
 
     reference.as = _.camelCase(formater(`${prefix}${foreignKey.tableName}`));
   }

--- a/services/analyzer/sequelize-tables-analyzer.js
+++ b/services/analyzer/sequelize-tables-analyzer.js
@@ -97,9 +97,10 @@ function checkUnicity(primaryKeys, uniqueIndexes, columnName) {
 
 // NOTICE: Format the references depending on the type of the association
 function createReference(tableName, association, foreignKey, manyToManyForeignKey) {
+  const foreignKeyName = _.camelCase(foreignKey.columnName);
   const reference = {
     foreignKey: foreignKey.columnName,
-    foreignKeyName: `${_.camelCase(foreignKey.columnName)}Key`,
+    foreignKeyName: `${foreignKeyName}Key`,
     association,
   };
 
@@ -114,9 +115,9 @@ function createReference(tableName, association, foreignKey, manyToManyForeignKe
     reference.ref = foreignKey.tableName;
 
     const formater = association === ASSOCIATION_TYPE_HAS_MANY ? plural : singular;
-    const prefix = (singular(tableName) === formatAliasName(_.camelCase(foreignKey.columnName)))
+    const prefix = (singular(tableName) === formatAliasName(foreignKeyName))
       ? ''
-      : `${formatAliasName(_.camelCase(foreignKey.columnName))}_`;
+      : `${formatAliasName(foreignKeyName)}_`;
 
     reference.as = _.camelCase(formater(`${prefix}${foreignKey.tableName}`));
   }

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -139,10 +139,6 @@ function Dumper(config) {
     });
 
     const referencesDefinition = references.map((reference) => {
-      const expectedConventionalForeignKeyName = underscored
-        ? _.snakeCase(reference.foreignKey) : reference.foreignKey;
-      const foreignKeyColumnUnconventional = reference.foreignKeyName
-        !== expectedConventionalForeignKeyName;
       const isBelongsToMany = reference.association === 'belongsToMany';
 
       if (reference.targetKey) {
@@ -153,14 +149,12 @@ function Dumper(config) {
         return {
           ...reference,
           isBelongsToMany,
-          foreignKeyColumnUnconventional,
           targetKeyColumnUnconventional,
         };
       }
       return {
         ...reference,
         isBelongsToMany,
-        foreignKeyColumnUnconventional,
       };
     });
 

--- a/templates/app/models/sequelize-model.hbs
+++ b/templates/app/models/sequelize-model.hbs
@@ -30,8 +30,8 @@ module.exports = (sequelize, DataTypes) => {
       otherKey: '{{reference.otherKey}}',
     {{else}}
       foreignKey: {
-        name: '{{reference.foreignKeyName}}',{{#if reference.foreignKeyColumnUnconventional}}
-        field: '{{reference.foreignKey}}',{{/if}}
+        name: '{{reference.foreignKeyName}}',
+        field: '{{reference.foreignKey}}',
       },{{#if reference.targetKey }}
       target: {
         name: '{{reference.targetKey}}',{{#if reference.targetKeyColumnUnconventional}}

--- a/test/expected/sequelize/db-analysis-output/addresses.json
+++ b/test/expected/sequelize/db-analysis-output/addresses.json
@@ -35,7 +35,7 @@
         "association": "belongsTo",
         "ref": "users",
         "foreignKey": "user_id",
-        "foreignKeyName": "userId",
+        "foreignKeyName": "userIdKey",
         "as": "user"
       }
     ],

--- a/test/expected/sequelize/db-analysis-output/renderings.json
+++ b/test/expected/sequelize/db-analysis-output/renderings.json
@@ -54,21 +54,21 @@
         "association": "belongsTo",
         "ref": "environments",
         "foreignKey": "environmentId",
-        "foreignKeyName": "environmentIdUnconventionnal",
+        "foreignKeyName": "environmentIdUnconventionnalKey",
         "as": "environment"
       },
       {
         "association": "belongsTo",
         "ref": "teams",
         "foreignKey": "teamId",
-        "foreignKeyName": "teamId",
+        "foreignKeyName": "teamIdKey",
         "as": "team"
       },
       {
         "association": "belongsTo",
         "ref": "otherWithTarget",
         "foreignKey": "other",
-        "foreignKeyName": "other",
+        "foreignKeyName": "otherKey",
         "targetKey": "otherId",
         "as": "team2"
       },
@@ -76,7 +76,7 @@
         "association": "belongsTo",
         "ref": "film",
         "foreignKey": "filmKeyName",
-        "foreignKeyName": "filmKeyName",
+        "foreignKeyName": "filmKeyNameKey",
         "targetKey": "film_target_key",
         "as": "films"
       }

--- a/test/expected/sequelize/db-analysis-output/users.json
+++ b/test/expected/sequelize/db-analysis-output/users.json
@@ -28,7 +28,7 @@
         "association": "belongsToMany",
         "ref": "books",
         "foreignKey": "user_id",
-        "foreignKeyName": "userId",
+        "foreignKeyName": "userIdKey",
         "junctionTable": "user_books",
         "otherKey": "book_id"
       },
@@ -37,14 +37,14 @@
         "association": "hasMany",
         "ref": "reviews",
         "foreignKey": "user_id",
-        "foreignKeyName": "userId"
+        "foreignKeyName": "userIdKey"
       },
       {
         "as": "address",
         "association": "hasOne",
         "ref": "addresses",
         "foreignKey": "user_id",
-        "foreignKeyName": "userId"
+        "foreignKeyName": "userIdKey"
       }
     ],
     "primaryKeys": ["id"],

--- a/test/expected/sequelize/dumper-output/addresses.js.expected
+++ b/test/expected/sequelize/dumper-output/addresses.js.expected
@@ -29,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
   Addresses.associate = (models) => {
     Addresses.belongsTo(models.users, {
       foreignKey: {
-        name: 'userId',
+        name: 'userIdKey',
         field: 'user_id',
       },
       as: 'user',

--- a/test/expected/sequelize/dumper-output/renderings.js.expected
+++ b/test/expected/sequelize/dumper-output/renderings.js.expected
@@ -37,20 +37,22 @@ module.exports = (sequelize, DataTypes) => {
   Renderings.associate = (models) => {
     Renderings.belongsTo(models.environments, {
       foreignKey: {
-        name: 'environmentIdUnconventionnal',
+        name: 'environmentIdUnconventionnalKey',
         field: 'environmentId',
       },
       as: 'environment',
     });
     Renderings.belongsTo(models.teams, {
       foreignKey: {
-        name: 'teamId',
+        name: 'teamIdKey',
+        field: 'teamId',
       },
       as: 'team',
     });
     Renderings.belongsTo(models.otherWithTarget, {
       foreignKey: {
-        name: 'other',
+        name: 'otherKey',
+        field: 'other',
       },
       target: {
         name: 'otherId',
@@ -59,7 +61,8 @@ module.exports = (sequelize, DataTypes) => {
     });
     Renderings.belongsTo(models.film, {
       foreignKey: {
-        name: 'filmKeyName',
+        name: 'filmKeyNameKey',
+        field: 'filmKeyName',
       },
       target: {
         name: 'film_target_key',

--- a/test/expected/sequelize/dumper-output/users.js.expected
+++ b/test/expected/sequelize/dumper-output/users.js.expected
@@ -31,14 +31,14 @@ module.exports = (sequelize, DataTypes) => {
     });
     Users.hasMany(models.reviews, {
       foreignKey: {
-        name: 'userId',
+        name: 'userIdKey',
         field: 'user_id',
       },
       as: 'reviews',
     });
     Users.hasOne(models.addresses, {
       foreignKey: {
-        name: 'userId',
+        name: 'userIdKey',
         field: 'user_id',
       },
       as: 'address',


### PR DESCRIPTION
If the two part of an association share the same string as an alias and a foreignKeyName, sequelize will crash.