### PR TITLE
Command Generate - Ensure that generated project on MongoDB use the latest `mongoose` dependency version for security reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Changed
-- Technical - Upgrade `mongoose` to the latest version in template.
+- Command Generate - Ensure that generated project on MongoDB use the latest `mongoose` dependency version for security reasons.
 
 ## RELEASE 3.1.0 - 2019-12-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Technical - Upgrade `mongoose` to the latest version in template.
 
 ## RELEASE 3.1.0 - 2019-12-20
 ### Added

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -55,7 +55,7 @@ function Dumper(config) {
         dependencies.tedious = '^6.4.0';
       } else if (config.dbDialect === 'mongodb') {
         delete dependencies.sequelize;
-        dependencies.mongoose = '~5.3.6';
+        dependencies.mongoose = '~5.8.2';
       }
     }
 
@@ -209,7 +209,7 @@ function Dumper(config) {
   }
 
   function writeModelsIndex() {
-    const templatePath = `${__dirname}/../templates/app/models/index.js`;
+    const templatePath = `${__dirname}/../templates/app/models/index.txt`;
     const template = _.template(fs.readFileSync(templatePath, 'utf-8'));
     const text = template({ config });
 

--- a/templates/app/models/index.txt
+++ b/templates/app/models/index.txt
@@ -1,6 +1,6 @@
 <% if (config.dbDialect === 'mongodb') {
 %>const mongoose = require('mongoose');
-mongoose.connect(process.env.DATABASE_URL, { useNewUrlParser: true });
+mongoose.connect(process.env.DATABASE_URL, { useNewUrlParser: true, useUnifiedTopology: true });
 module.exports = mongoose.models;
 <% } else {
 %>const fs = require('fs');


### PR DESCRIPTION
@arnaudbesnier I selected you as a reviewer for the following reasons:
 - We discussed about this on slack.
 - You made this commit: https://github.com/ForestAdmin/forest-express-mongoose/commit/9ee264ef8e1b6ae4103311d7b06b68581558535a.

Three things as been done (because it did not work without that):
 - Since the linter do not accept template-like file, I had to rename `templates/app/models/index.js` to  `templates/app/models/index.txt` (the commit can not pass without that). On a side note, the template system is currently messy: a mix of `txt` files, `js` files with invalid javascript (like this one) and handlebars code. We should improve that.
 - I had to add `useUnifiedTopology: true` in connect. Without this, there is a warning: https://mongoosejs.com/docs/deprecations.html#useunifiedtopology (we do not use any of the option that can generate a problem: `autoReconnect, reconnectTries, reconnectInterval`.
 - The change itself: upgrading to 5.8.2

<img width="555" alt="Capture d’écran 2019-12-23 à 16 01 15" src="https://user-images.githubusercontent.com/1575946/71365898-9e5b4c80-25a0-11ea-9866-e2b227fd963a.png">

