### PR TITLE
[*] Technical - Fix the missing dependencies in the `package.json` file of the generated project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Command Generate - Ensure that generated project on MongoDB use the latest `mongoose` dependency version for security reasons.
 - Technical - Use Jest instead of Mocha for the test base.
 
+### Fixed
+- Technical - Fix the missing dependencies in the `package.json` file of the generated project.
+
 ## RELEASE 3.1.0 - 2019-12-20
 ### Added
 - Command Generate - Generate MongoDB HasMany.

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -37,9 +37,11 @@ function Dumper(config) {
     const dependencies = {
       chalk: '~1.1.3',
       'cookie-parser': '1.4.4',
+      cors: '2.8.5',
       debug: '~4.0.1',
       dotenv: '~6.1.0',
       express: '~4.16.3',
+      'express-jwt': '5.3.1',
       [`forest-express-${orm}`]: '^5.2.0',
       morgan: '1.9.1',
       'require-all': '^3.0.0',


### PR DESCRIPTION
I added the same package version as the `forest-express` package to prevent unexpected issues (as it was the forest-express dependency that was bringing the packages to the project).