### PR TITLE
[*] Command Generate - Validate and fix the package name in `package.json` to prevent error on generated server startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
 - Technical - Fix the NPM package description.
 - Command Generate - Prevent project creation with impossible liana login (if the database contains a "sessions" table).
 
+### Fixed
+- Command Generate - Validate and fix the package name in `package.json` to prevent error on generated server startup.
+
 ## RELEASE 3.1.0 - 2019-12-20
 ### Added
 - Command Generate - Generate MongoDB HasMany.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Command Generate - Do not generate obsolete `bin` path.
+- Command Generate - Validate and fix the package name in `package.json` to prevent error on generated server startup.
 
 ## RELEASE 3.3.0 - 2020-01-06
 ### Added
@@ -38,9 +39,6 @@
 - Technical - Fix the missing dependencies in the `package.json` file of the generated project.
 - Technical - Fix the NPM package description.
 - Command Generate - Prevent project creation with impossible liana login (if the database contains a "sessions" table).
-
-### Fixed
-- Command Generate - Validate and fix the package name in `package.json` to prevent error on generated server startup.
 
 ## RELEASE 3.1.0 - 2019-12-20
 ### Added

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "spinnies": "0.5.0",
     "superagent": "5.1.0",
     "tedious": "6.4.0",
+    "validate-npm-package-name": "^3.0.0",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "spinnies": "0.5.0",
     "superagent": "5.1.0",
     "tedious": "6.4.0",
-    "validate-npm-package-name": "^3.0.0",
+    "validate-npm-package-name": "3.0.0",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -7,6 +7,7 @@ const chalk = require('chalk');
 const { plural, singular } = require('pluralize');
 const stringUtils = require('../utils/strings');
 const logger = require('./logger');
+const toValidPackageName = require('../utils/to-valid-package-name');
 require('../handlerbars/loader');
 
 const mkdirp = P.promisify(mkdirpSync);
@@ -62,7 +63,7 @@ function Dumper(config) {
     }
 
     const pkg = {
-      name: config.appName.replace(/ /g, '_').toLowerCase(),
+      name: toValidPackageName(config.appName),
       version: '0.0.1',
       private: true,
       scripts: { start: 'node ./server.js' },

--- a/test/utils-to-valid-package-name.test.js
+++ b/test/utils-to-valid-package-name.test.js
@@ -1,0 +1,40 @@
+// FIXME: This file has to be moved inside `utils/folder` as soon
+//        as test helpers are moved outside the `utils` folder.
+const toValidPackageName = require('../utils/to-valid-package-name');
+
+describe('utils > toValidPackageName', () => {
+  it('should not convert valid package names', () => {
+    expect.assertions(7);
+
+    const names = [
+      'some-package',
+      'example.com',
+      'under_score',
+      '123numeric',
+      '@npm/thingy',
+      '@jane/foo.js',
+      '-',
+    ];
+
+    names.forEach((name) => {
+      expect(toValidPackageName(name)).toStrictEqual(name);
+    });
+  });
+
+  it('should convert invalid package names to valid package names', () => {
+    expect.assertions(6);
+
+    const names = [
+      { original: 'with space', expected: 'with-space' },
+      { original: '  with many   space   ', expected: 'with-many-space' },
+      { original: 'SHOULD BE LOWER CASE', expected: 'should-be-lower-case' },
+      { original: '--a¨*£%¨*+/.?:=›Îﬂ---z-', expected: 'a-z' },
+      { original: '∆™Ÿª', expected: 'my-lumber-project' },
+      { original: '', expected: 'my-lumber-project' },
+    ];
+
+    names.forEach((name) => {
+      expect(toValidPackageName(name.original)).toStrictEqual(name.expected);
+    });
+  });
+});

--- a/test/utils-to-valid-package-name.test.js
+++ b/test/utils-to-valid-package-name.test.js
@@ -29,8 +29,8 @@ describe('utils > toValidPackageName', () => {
       { original: '  with many   space   ', expected: 'with-many-space' },
       { original: 'SHOULD BE LOWER CASE', expected: 'should-be-lower-case' },
       { original: '--a¨*£%¨*+/.?:=›Îﬂ---z-', expected: 'a-z' },
-      { original: '∆™Ÿª', expected: 'my-lumber-project' },
-      { original: '', expected: 'my-lumber-project' },
+      { original: '∆™Ÿª', expected: 'lumber-project' },
+      { original: '', expected: 'lumber-project' },
     ];
 
     names.forEach((name) => {

--- a/test/utils-to-valid-package-name.test.js
+++ b/test/utils-to-valid-package-name.test.js
@@ -1,4 +1,4 @@
-// FIXME: This file has to be moved inside `utils/folder` as soon
+// FIXME: This file has to be moved inside `utils` folder as soon
 //        as test helpers are moved outside the `utils` folder.
 const toValidPackageName = require('../utils/to-valid-package-name');
 

--- a/utils/to-valid-package-name.js
+++ b/utils/to-valid-package-name.js
@@ -1,0 +1,21 @@
+const validate = require('validate-npm-package-name');
+
+module.exports = function toValidPackageName(packageName) {
+  const { validForNewPackages, validForOldPackages } = validate(packageName);
+  const isValid = validForNewPackages && validForOldPackages;
+
+  if (!isValid) {
+    // NOTICE: hard slugify mode (disallow almost everything)
+    return packageName.toLowerCase()
+      // Remove all non "a-z", "0-9", "-" characters with hyphen.
+      .replace(/[^a-z0-9\\-]/g, '-')
+      // Remove hyphen sequence (> 1).
+      .replace(/-{2,}/g, '-')
+      // Remove leading and trailing hyphen.
+      .replace(/^-|-$/g, '')
+      // If empty, replace with my-lumber-project.
+      .replace(/^-*$/g, 'my-lumber-project');
+  }
+
+  return packageName;
+};

--- a/utils/to-valid-package-name.js
+++ b/utils/to-valid-package-name.js
@@ -2,8 +2,8 @@ const validate = require('validate-npm-package-name');
 
 module.exports = function toValidPackageName(packageName) {
   function isValid(name) {
-    const { validForNewPackages, validForOldPackages } = validate(name);
-    return validForNewPackages && validForOldPackages;
+    const { validForNewPackages } = validate(name);
+    return validForNewPackages;
   }
 
   if (!isValid(packageName)) {

--- a/utils/to-valid-package-name.js
+++ b/utils/to-valid-package-name.js
@@ -5,7 +5,7 @@ module.exports = function toValidPackageName(packageName) {
   const isValid = validForNewPackages && validForOldPackages;
 
   if (!isValid) {
-    // NOTICE: hard slugify mode (disallow almost everything)
+    // NOTICE: Create an always valid package name (disallow almost everything)
     return packageName.toLowerCase()
       // Remove all non "a-z", "0-9", "-" characters with hyphen.
       .replace(/[^a-z0-9\\-]/g, '-')

--- a/utils/to-valid-package-name.js
+++ b/utils/to-valid-package-name.js
@@ -1,20 +1,23 @@
 const validate = require('validate-npm-package-name');
 
 module.exports = function toValidPackageName(packageName) {
-  const { validForNewPackages, validForOldPackages } = validate(packageName);
-  const isValid = validForNewPackages && validForOldPackages;
+  function isValid(name) {
+    const { validForNewPackages, validForOldPackages } = validate(name);
+    return validForNewPackages && validForOldPackages;
+  }
 
-  if (!isValid) {
+  if (!isValid(packageName)) {
     // NOTICE: Create an always valid package name (disallow almost everything)
-    return packageName.toLowerCase()
+    const validPackageName = packageName.toLowerCase()
       // Remove all non "a-z", "0-9", "-" characters with hyphen.
       .replace(/[^a-z0-9\\-]/g, '-')
       // Remove hyphen sequence (> 1).
       .replace(/-{2,}/g, '-')
       // Remove leading and trailing hyphen.
-      .replace(/^-|-$/g, '')
-      // If empty, replace with my-lumber-project.
-      .replace(/^-*$/g, 'my-lumber-project');
+      .replace(/^-|-$/g, '');
+
+    // NOTICE: Return 'lumber-project' if sanitized package name is still not valid.
+    return isValid(validPackageName) ? validPackageName : 'lumber-project';
   }
 
   return packageName;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4926,7 +4926,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validate-npm-package-name@^3.0.0:
+validate-npm-package-name@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=

--- a/yarn.lock
+++ b/yarn.lock
@@ -952,6 +952,11 @@ buffer-writer@1.0.1:
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-1.0.1.tgz#22a936901e3029afcd7547eb4487ceb697a3bf08"
   integrity sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg=
 
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
+  integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -4920,6 +4925,13 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
+  dependencies:
+    builtins "^1.0.3"
 
 validator@^10.11.0:
   version "10.11.0"


### PR DESCRIPTION
### Description

This fix avoids an error on project startup when project name is not allowed as a package name.

It uses the official [validate-npm-package-name](https://www.npmjs.com/package/validate-npm-package-name) created by NPM team to validate the project name. If the validation fails, it tries to transform the string to something that works (since slugify is not sufficient and I did not found a lib, I created a grumpy transformer that disallow almost everything when validation fails).

### Side note about tests
(see: https://forestadmin.slack.com/archives/GAZF5Q5RV/p1577712751015700)

I can not have created a unit test about the new created function in a `utils` directory because it's already used by tests' utils; migrating the existing system is not _that_ simple (see Slack discussion). We have to find a way to do that, but since we don't like to mix subject in one PR, I have to postpone this one. That's why I named the test file `test/utils-to-valid-package-name.test.js` (it should have been `test/utils/to-valid-package-name.test.js`). See this Trello card about this side note: https://trello.com/c/FaSVaFbY/2169-lumber-move-test-helpers-out-of-test-utils-folder