### PR TITLE
[*] Command Generate - Do not generate obsolete `bin` path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Command Generate - Do not generate obsolete `bin` path.
 
 ## RELEASE 3.3.0 - 2020-01-06
 ### Added

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -15,7 +15,6 @@ const DEFAULT_PORT = 3310;
 
 function Dumper(config) {
   const path = `${process.cwd()}/${config.appName}`;
-  const binPath = `${path}/bin`;
   const routesPath = `${path}/routes`;
   const forestPath = `${path}/forest`;
   const publicPath = `${path}/public`;
@@ -267,7 +266,6 @@ function Dumper(config) {
   this.dump = async (schema) => {
     const directories = [
       mkdirp(path),
-      mkdirp(binPath),
       mkdirp(routesPath),
       mkdirp(forestPath),
       mkdirp(viewPath),


### PR DESCRIPTION
`bin` path is not used anymore in Lumber generated projects. This PR removes the `bin` path generation. 

@arnaud-moncel We have seen this issue during the demo of Lumber this morning. You have to test generating a project with this branch to ensure it works. Let me know if you need any help in testing this!