### PR TITLE
[*] Command Generate - Fix error on array type generation for PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Command Generate - Fix error on array type generation for PostgreSQL.
 
 ## RELEASE 3.3.1 - 2020-01-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
-- Command Generate - Fix error on array type generation for PostgreSQL.
+- Command Generate - Fix error on array type generation for PostgreSQL. 🛡
 
 ## RELEASE 3.3.1 - 2020-01-14
 ### Added

--- a/services/analyzer/sequelize-column-type-getter.js
+++ b/services/analyzer/sequelize-column-type-getter.js
@@ -66,11 +66,11 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
     return 'STRING';
   }
 
-  async function getTypeForArray(tableName, columnName) {
+  this.getTypeForArray = async (tableName, columnName) => {
     if (!isDialect(DIALECT_POSTGRES)) { return null; }
     const innerColumnInfo = await getTypeOfArrayForPostgres(tableName, columnName);
     return `ARRAY(DataTypes.${await this.perform(innerColumnInfo, innerColumnInfo.udtName, tableName)})`;
-  }
+  };
 
   this.perform = async (columnInfo, columnName, tableName) => {
     const { type } = columnInfo;
@@ -126,7 +126,7 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
       case 'TIME WITHOUT TIME ZONE':
         return 'TIME';
       case 'ARRAY': {
-        return getTypeForArray(tableName, columnName);
+        return this.getTypeForArray(tableName, columnName);
       }
       case 'INET':
         return 'INET';

--- a/test-fixtures/postgres/employees.sql
+++ b/test-fixtures/postgres/employees.sql
@@ -1,0 +1,4 @@
+create table employees (
+	name varchar,
+	pay_by_quarter integer ARRAY
+);

--- a/test-fixtures/postgres/employees.sql
+++ b/test-fixtures/postgres/employees.sql
@@ -1,4 +1,4 @@
 create table employees (
-	name varchar,
-	pay_by_quarter integer ARRAY
+  name varchar,
+  pay_by_quarter integer ARRAY
 );

--- a/test/services/sequelize-column-type-getter.test.js
+++ b/test/services/sequelize-column-type-getter.test.js
@@ -25,10 +25,24 @@ describe('services > column type getter', () => {
       const sequelizeHelper = new SequelizeHelper();
       const databaseConnection = await sequelizeHelper.connect(DATABASE_URL_POSTGRESQL_MAX);
       await sequelizeHelper.dropAndCreate('customers');
-      const columnTypeGetter = new ColumnTypeGetter(databaseConnection, '');
+      const columnTypeGetter = new ColumnTypeGetter(databaseConnection, 'public');
       const computedType = await columnTypeGetter.perform({ type: 'BIT(1)' }, 'paying', 'customers');
 
       expect(computedType).toBeNull();
+
+      await sequelizeHelper.drop('customers', 'postgres');
+      await sequelizeHelper.close();
+    });
+
+    it('should handle `integer ARRAY` as ARRAY(DataTypes.INTEGER)', async () => {
+      expect.assertions(1);
+      const sequelizeHelper = new SequelizeHelper();
+      const databaseConnection = await sequelizeHelper.connect(DATABASE_URL_POSTGRESQL_MAX);
+      await sequelizeHelper.dropAndCreate('employees');
+      const columnTypeGetter = new ColumnTypeGetter(databaseConnection, 'public');
+      const computedType = await columnTypeGetter.perform({ type: 'ARRAY' }, 'pay_by_quarter', 'employees');
+
+      expect(computedType).toStrictEqual('ARRAY(DataTypes.INTEGER)');
 
       await sequelizeHelper.drop('customers', 'postgres');
       await sequelizeHelper.close();

--- a/test/services/sequelize-column-type-getter.test.js
+++ b/test/services/sequelize-column-type-getter.test.js
@@ -34,7 +34,7 @@ describe('services > column type getter', () => {
       await sequelizeHelper.close();
     });
 
-    it('should handle `integer ARRAY` as ARRAY(DataTypes.INTEGER)', async () => {
+    it('should handle `integer ARRAY` as `ARRAY(DataTypes.INTEGER)`', async () => {
       expect.assertions(1);
       const sequelizeHelper = new SequelizeHelper();
       const databaseConnection = await sequelizeHelper.connect(DATABASE_URL_POSTGRESQL_MAX);
@@ -44,7 +44,7 @@ describe('services > column type getter', () => {
 
       expect(computedType).toStrictEqual('ARRAY(DataTypes.INTEGER)');
 
-      await sequelizeHelper.drop('customers', 'postgres');
+      await sequelizeHelper.drop('employees', 'postgres');
       await sequelizeHelper.close();
     });
   });


### PR DESCRIPTION
See: https://forestadmin.slack.com/archives/C0FQF9Z52/p1579162444286500

> Hi, I just tried to run `lumber generate`  as per the documentation during onboarding.   I immediately got this error

```
✓ Connecting to your database
✖ Analyzing the database
> Cannot generate your project.
> An unexpected error occurred. Please reach out for help in our Slack community or create a Github issue with following error: TypeError: this.perform is not a function
(node:9725) UnhandledPromiseRejectionWarning: TypeError: this.perform is not a function
    at getTypeForArray (/home/ryan/.nvm/versions/node/v12.13.1/lib/node_modules/lumber-cli/services/analyzer/sequelize-column-type-getter.js:72:42)
    at async /home/ryan/.nvm/versions/node/v12.13.1/lib/node_modules/lumber-cli/services/analyzer/sequelize-tables-analyzer.js:253:18
(node:9725) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
```

Introduced here: https://github.com/ForestAdmin/lumber/commit/c68860210526edad5e49dd7d489e34da2790f449