### PR TITLE
[+] Command Generate - Add support for MySQL 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Command Generate - Add support for MySQL 8.
+
 ### Fixed
 - Command Generate - Fix error on project generation with database contain table with number as name.
 
 ### Changed
 - Tests - Use MySQL 8.0 as the max supported MySQL version.
+- Technical - Update `mysql2` dependency to 2 (latest MAJOR version).
 
 ## RELEASE 3.3.3 - 2020-01-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 - Command Generate - Fix error on project generation with database contain table with number as name.
 
+### Changed
+- Tests - Use MySQL 8.0 as the max supported MySQL version.
+
 ## RELEASE 3.3.3 - 2020-01-23
 ### Changed
 - Technical - Use handlebars for all templates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### Changed
 - Tests - Use MySQL 8.0 as the max supported MySQL version.
-- Technical - Update `mysql2` dependency to 2 (latest MAJOR version).
 
 ### Fixed
 - Command Generate - Fix error on project generation with database contain table with number as name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 ### Added
 - Command Generate - Add support for MySQL 8.
 
-### Fixed
-- Command Generate - Fix error on project generation with database contain table with number as name.
-
 ### Changed
 - Tests - Use MySQL 8.0 as the max supported MySQL version.
 - Technical - Update `mysql2` dependency to 2 (latest MAJOR version).
+
+### Fixed
+- Command Generate - Fix error on project generation with database contain table with number as name.
 
 ## RELEASE 3.3.3 - 2020-01-23
 ### Changed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ MySQL-MIN:
     - "127.0.0.1:8998:3306"
 
 MySQL-MAX:
-  image: mysql:5.7
+  image: mysql:8.0
   container_name: test_lumber_mysql_max
   environment:
     MYSQL_ROOT_PASSWORD: secret

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "mongodb": "3.3.0",
-    "mysql2": "1.7.0",
+    "mysql2": "2.1.0",
     "pg": "^6.1.0",
     "pluralize": "^8.0.0",
     "saslprep": "1.0.3",

--- a/test-utils/multiple-database-version-helper.js
+++ b/test-utils/multiple-database-version-helper.js
@@ -24,7 +24,7 @@ const sqlDatabases = [{
   schema: 'public',
 }, {
   dialect: 'mysql',
-  version: '5.7',
+  version: '8.0',
   connectionUrl: DATABASE_URL_MYSQL_MAX,
   schema: 'public',
 }, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,6 +676,11 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansicolors@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
+  integrity sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=
+
 any-promise@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
@@ -988,6 +993,14 @@ capture-exit@^2.0.0:
   integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
   dependencies:
     rsvp "^4.8.4"
+
+cardinal@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-2.1.1.tgz#7cc1055d822d212954d07b085dea251cc7bc5505"
+  integrity sha1-fMEFXYItISlU0HsIXeolHMe8VQU=
+  dependencies:
+    ansicolors "~0.3.2"
+    redeyed "~2.1.0"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1572,7 +1585,7 @@ esprima@^3.1.3:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -3303,11 +3316,12 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mysql2@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-1.7.0.tgz#2fbf314da016a61d038ffcd57a2a0aa3b7b8eacc"
-  integrity sha512-xTWWQPjP5rcrceZQ7CSTKR/4XIDeH/cRkNH/uzvVGQ7W5c7EJ0dXeJUusk7OKhIoHj7uFKUxDVSCfLIl+jluog==
+mysql2@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-2.1.0.tgz#55ecfd4353114c148cc4c253192dbbfd000e6642"
+  integrity sha512-9kGVyi930rG2KaHrz3sHwtc6K+GY9d8wWk1XRSYxQiunvGcn4DwuZxOwmK11ftuhhwrYDwGx9Ta4VBwznJn36A==
   dependencies:
+    cardinal "^2.1.1"
     denque "^1.4.1"
     generate-function "^2.3.1"
     iconv-lite "^0.5.0"
@@ -3958,6 +3972,13 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+redeyed@~2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-2.1.1.tgz#8984b5815d99cb220469c99eeeffe38913e6cc0b"
+  integrity sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=
+  dependencies:
+    esprima "~4.0.0"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
 - Tests works locally and remotely.
 - No need to downgrade password.
 - `mysql2` has been updated to latest MAJOR version (2) (https://github.com/sidorares/node-mysql2/blob/master/Changelog.md)