### PR TITLE
Command Generate - Export ID fields and force isReadOnly property where needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Command Generate - Fix error on project generation with database contain table with number as name.
 - Command Generate - Fix allowed origin to only allow forestadmin domain and not domain finishing by forestadmin.
 - Command Generate - Fix error on project generation when tables have references on table with non safe name.
+- Command Generate - Export ID fields and force isReadOnly property where needed.
 
 ## RELEASE 3.3.3 - 2020-01-23
 ### Changed

--- a/services/analyzer/sequelize-tables-analyzer.js
+++ b/services/analyzer/sequelize-tables-analyzer.js
@@ -258,10 +258,14 @@ async function createTableSchema({
     // NOTICE: If the column is of integer type, named "id" and primary, Sequelize will handle it
     //         automatically without necessary declaration.
     const isIdIntegerPrimaryColumn = columnName === 'id'
-      && ['INTEGER', 'BIGINT'].includes(type)
+      && ['BIGINT', 'INTEGER', 'UUID'].includes(type)
       && columnInfo.primaryKey;
+    // NOTICE: Columns named `id` with a default value and set as a Primary Key are Read Only
+    //         by default. Other columns are Writable by default.
+    // TODO: Only columns with a sequence or expression default value should be Read Only
+    const isReadOnlyColumn = isIdIntegerPrimaryColumn && columnInfo.defaultValue !== null;
 
-    if (isValidField && !isIdIntegerPrimaryColumn) {
+    if (isValidField && !(isIdIntegerPrimaryColumn && isReadOnlyColumn)) {
       // NOTICE: Handle bit(1) to boolean conversion
       let { defaultValue } = columnInfo;
 
@@ -278,6 +282,7 @@ async function createTableSchema({
         type,
         primaryKey: columnInfo.primaryKey,
         defaultValue,
+        isReadOnly: isReadOnlyColumn,
       };
 
       fields.push(field);

--- a/templates/app/models/sequelize-model.hbs
+++ b/templates/app/models/sequelize-model.hbs
@@ -11,6 +11,7 @@ module.exports = (sequelize, DataTypes) => {
       field: '{{field.nameColumn}}',{{/if}}{{#if field.primaryKey}}
       primaryKey: true,{{/if}}{{#if field.defaultValue}}
       defaultValue: Sequelize.literal('{{{field.defaultValue}}}'),{{/if}}
+      isReadOnly: {{field.isReadOnly}},
     },
 {{/each}}
   }, {


### PR DESCRIPTION
This adds information, but `isReadOnly: false` is not honoured by frontend.