### PR TITLE
fix(generate): fix database url encoded in .env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Technical - Adapt release manager to conventional commits.
 - Documentation - Update links in readme.
 
+### Fixed
+- Command Generate - Fix DATABASE_URL badly encoded in .env generation.
+
 ## RELEASE 3.5.1 - 2020-04-06
 ### Fixed
 - Command Generate - Remove extraneous calls to Sequelize.literal in generated models.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Documentation - Update links in readme.
 
 ### Fixed
-- Command Generate - Fix DATABASE_URL badly encoded in .env generation.
+- Command Generate - Prevent files' content from being HTML escaped.
 
 ## RELEASE 3.5.1 - 2020-04-06
 ### Fixed

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -49,6 +49,7 @@ function Dumper(config) {
     function handlebarsTemplate(templatePath) {
       return Handlebars.compile(
         fs.readFileSync(`${__dirname}/../templates/${templatePath}`, 'utf-8'),
+        { noEscape: true },
       );
     }
 


### PR DESCRIPTION
# Description
When installing a project with a mongo project with an authSource, the `=` get encoded

# Actual behaviour
I get a DATABASE_URL=mongo.....?authSource&#x3D;admin
So the server does not start

# Expected behaviour
To not have an encoded DATABASE_URL