### PR TITLE
refactor: reduce sequelize-column-type-getter code complexity

### DIFF
--- a/services/analyzer/sequelize-column-type-getter.js
+++ b/services/analyzer/sequelize-column-type-getter.js
@@ -4,7 +4,7 @@ const logger = require('../logger');
 const DIALECT_MYSQL = 'mysql';
 const DIALECT_POSTGRES = 'postgres';
 
-const typeMatch = (type, value) => type.match(value || {}).input;
+const typeMatch = (type, value) => (type.match(value) || {}).input;
 const typeStartsWith = (type, value) => typeMatch(type, new RegExp(`^${value}.*`, 'i'));
 const typeContains = (type, value) => typeMatch(type, new RegExp(`${value}.*`, 'i'));
 

--- a/services/analyzer/sequelize-column-type-getter.js
+++ b/services/analyzer/sequelize-column-type-getter.js
@@ -4,6 +4,10 @@ const logger = require('../logger');
 const DIALECT_MYSQL = 'mysql';
 const DIALECT_POSTGRES = 'postgres';
 
+const typeMatch = (type, value) => type.match(value || {}).input;
+const typeStartsWith = (type, value) => typeMatch(type, new RegExp(`^${value}.*`, 'i'));
+const typeContains = (type, value) => typeMatch(type, new RegExp(`${value}.*`, 'i'));
+
 function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
   const queryInterface = databaseConnection.getQueryInterface();
 
@@ -74,7 +78,6 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
 
   this.perform = async (columnInfo, columnName, tableName) => {
     const { type } = columnInfo;
-    const mysqlEnumRegex = /ENUM\((.*)\)/i;
 
     switch (type) {
       case (type === 'BIT(1)' && isDialect(DIALECT_MYSQL) && 'BIT(1)'): // NOTICE: MySQL boolean type.
@@ -84,15 +87,14 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
       case 'CHARACTER VARYING':
       case 'TEXT':
       case 'NTEXT': // MSSQL type
-      case (type.match(/TEXT.*/i) || {}).input:
-      case (type.match(/VARCHAR.*/i) || {}).input:
-      case (type.match(/CHAR.*/i) || {}).input:
+      case typeContains(type, 'TEXT'):
+      case typeContains(type, 'VARCHAR'):
+      case typeContains(type, 'CHAR'):
       case 'NVARCHAR': // NOTICE: MSSQL type.
         return 'STRING';
-      case 'USER-DEFINED': {
+      case 'USER-DEFINED':
         return getTypeForUserDefined(columnName, columnInfo);
-      }
-      case (type.match(mysqlEnumRegex) || {}).input:
+      case typeMatch(type, /ENUM\((.*)\)/i):
         return type;
       case 'UNIQUEIDENTIFIER':
       case 'UUID':
@@ -102,32 +104,31 @@ function ColumnTypeGetter(databaseConnection, schema, allowWarning = true) {
       case 'INTEGER':
       case 'SERIAL':
       case 'BIGSERIAL':
-      case (type.match(/^INT.*/i) || {}).input:
-      case (type.match(/^SMALLINT.*/i) || {}).input:
-      case (type.match(/^TINYINT.*/i) || {}).input:
+      case typeStartsWith(type, 'INT'):
+      case typeStartsWith(type, 'SMALLINT'):
+      case typeStartsWith(type, 'TINYINT'):
         return 'INTEGER';
-      case (type.match(/^BIGINT.*/i) || {}).input:
+      case typeStartsWith(type, 'BIGINT'):
         return 'BIGINT';
-      case (type.match(/FLOAT.*/i) || {}).input:
+      case typeContains(type, 'FLOAT'):
         return 'FLOAT';
       case 'NUMERIC':
       case 'DECIMAL':
       case 'REAL':
       case 'DOUBLE':
       case 'DOUBLE PRECISION':
-      case (type.match(/DECIMAL.*/i) || {}).input:
+      case typeContains(type, 'DECIMAL'):
       case 'MONEY': // MSSQL type
         return 'DOUBLE';
       case 'DATE':
       case 'DATETIME':
-      case (type.match(/^TIMESTAMP.*/i) || {}).input:
+      case typeStartsWith(type, 'TIMESTAMP'):
         return 'DATE';
       case 'TIME':
       case 'TIME WITHOUT TIME ZONE':
         return 'TIME';
-      case 'ARRAY': {
+      case 'ARRAY':
         return this.getTypeForArray(tableName, columnName);
-      }
       case 'INET':
         return 'INET';
       default:


### PR DESCRIPTION
## Description

See: https://github.com/ForestAdmin/lumber/pull/430
The goal is to avoid this: https://github.com/ForestAdmin/lumber/pull/430/files#diff-0ba9ef715c22f8ab287bcf3e5eb8e25bR76

Explantation here: https://github.com/ForestAdmin/lumber/pull/424/files#r422876644 (copy/paste below)

## Copy/paste

I feel like we should try to avoid introducing cognitive complexity. The complexity was already there, you added one line, so it's not your responsibility. We also should not mix refactor and feature introduction. 

**But**, I think we could prefer a refactoring task over adding `eslint-disable-next-line`. WDYT?

### Suggestion (original description)

A small refactor could be replacing all these occurrence (they are considered as "complex" by the linter, we could consider these as duplicate):

```js
case type.match(/^SMALLINT.*/i) || {}).input:
```

With:
```js
case typeStartingWith(type, 'SMALLINT'):
```

Then create a function:
```js
function typeStartingWith(type, value) {
  return type.match(new RegExp(`^${value}.*`, 'i') || {}).input;
}
```

I just checked (I did not tested it though), it's enough to reduce the complexity detected by sonarJS. It also removes 11 duplicates lines. Still, I'm aware this is not related to this actual issue. Feel free to suggest something else (however, I feel like we have to do something to address this `eslint-disable` issue).

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Create automatic tests
- [x] No automatic tests failures
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
