### PR TITLE
fix: model generation inconsistencies

### DIFF
--- a/services/analyzer/sequelize-tables-analyzer.js
+++ b/services/analyzer/sequelize-tables-analyzer.js
@@ -371,6 +371,12 @@ async function analyzeSequelizeTables(databaseConnection, config, allowWarning) 
   const referencesPerTable = createAllReferences(databaseSchema, schemaAllTables);
   Object.keys(referencesPerTable).forEach((tableName) => {
     schemaAllTables[tableName].references = _.sortBy(referencesPerTable[tableName], 'association');
+
+    if (!schemaAllTables[tableName].fields.length) {
+      schemaAllTables[tableName].options.underscored = isUnderscored(
+        schemaAllTables[tableName].references.map(({ foreignKey }) => ({ nameColumn: foreignKey })),
+      );
+    }
   });
 
   if (_.isEmpty(schemaAllTables)) {

--- a/services/analyzer/sequelize-tables-analyzer.js
+++ b/services/analyzer/sequelize-tables-analyzer.js
@@ -372,6 +372,9 @@ async function analyzeSequelizeTables(databaseConnection, config, allowWarning) 
   Object.keys(referencesPerTable).forEach((tableName) => {
     schemaAllTables[tableName].references = _.sortBy(referencesPerTable[tableName], 'association');
 
+    // NOTE: When a table contains no field, it will be considered camelCased
+    //       by default, so we need to check its references to ensure whether
+    //       it is camelCased or not.
     if (!schemaAllTables[tableName].fields.length) {
       schemaAllTables[tableName].options.underscored = isUnderscored(
         schemaAllTables[tableName].references.map(({ foreignKey }) => ({ nameColumn: foreignKey })),

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -210,8 +210,12 @@ function Dumper(config) {
       }
 
       if (reference.targetKey) {
+        const expectedConventionalTargetKeyName = underscored
+          ? _.snakeCase(reference.targetKey)
+          : _.camelCase(reference.targetKey);
+
         computedReference.targetKeyColumnUnconventional = reference.targetKey
-          !== (underscored ? _.snakeCase(reference.targetKey) : _.camelCase(reference.targetKey));
+          !== expectedConventionalTargetKeyName;
       }
 
       return computedReference;

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -200,23 +200,21 @@ function Dumper(config) {
     });
 
     const referencesDefinition = references.map((reference) => {
-      const isBelongsToMany = reference.association === 'belongsToMany';
+      const computedReference = {
+        ...reference,
+        isBelongsToMany: reference.association === 'belongsToMany',
+      };
+
+      if (reference.junctionTable) {
+        computedReference.junctionTable = _.camelCase(reference.junctionTable);
+      }
 
       if (reference.targetKey) {
-        const expectedConventionalTargetKeyName = underscored
-          ? _.snakeCase(reference.targetKey) : _.camelCase(reference.targetKey);
-        const targetKeyColumnUnconventional = reference.targetKey
-          !== expectedConventionalTargetKeyName;
-        return {
-          ...reference,
-          isBelongsToMany,
-          targetKeyColumnUnconventional,
-        };
+        computedReference.targetKeyColumnUnconventional = reference.targetKey
+          !== (underscored ? _.snakeCase(reference.targetKey) : _.camelCase(reference.targetKey));
       }
-      return {
-        ...reference,
-        isBelongsToMany,
-      };
+
+      return computedReference;
     });
 
     copyHandleBarsTemplate({

--- a/test-expected/sequelize/dumper-output/users.expected.js
+++ b/test-expected/sequelize/dumper-output/users.expected.js
@@ -25,7 +25,7 @@ module.exports = (sequelize, DataTypes) => {
   // This section contains the relationships for this model. See: https://docs.forestadmin.com/documentation/v/v6/reference-guide/relationships#adding-relationships.
   Users.associate = (models) => {
     Users.belongsToMany(models.books, {
-      through: 'user_books',
+      through: 'userBooks',
       foreignKey: 'user_id',
       otherKey: 'book_id',
     });

--- a/test-fixtures/mssql/sample_table.sql
+++ b/test-fixtures/mssql/sample_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE [dbo].sample_table (
+  id INT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/test-fixtures/mssql/underscored_no_fields.sql
+++ b/test-fixtures/mssql/underscored_no_fields.sql
@@ -1,0 +1,6 @@
+CREATE TABLE [dbo].underscored_no_fields (
+  id INT NOT NULL,
+  sample_table_id INT NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT underscored_no_fields_sample_table_id_fkey FOREIGN KEY (sample_table_id) REFERENCES [dbo].sample_table(id),
+);

--- a/test-fixtures/mysql/sample_table.sql
+++ b/test-fixtures/mysql/sample_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE sample_table (
+  id INT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/test-fixtures/mysql/underscored_no_fields.sql
+++ b/test-fixtures/mysql/underscored_no_fields.sql
@@ -1,0 +1,6 @@
+CREATE TABLE underscored_no_fields (
+  id INT NOT NULL,
+  sample_table_id INT NOT NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT underscored_no_fields_sample_table_id_fkey FOREIGN KEY (sample_table_id) REFERENCES sample_table(id) ON DELETE NO ACTION ON UPDATE CASCADE
+);

--- a/test-fixtures/postgres/sample_table.sql
+++ b/test-fixtures/postgres/sample_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE sample_table (
+  id INT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/test-fixtures/postgres/underscored_no_fields.sql
+++ b/test-fixtures/postgres/underscored_no_fields.sql
@@ -1,0 +1,6 @@
+CREATE TABLE underscored_no_fields (
+  id INT NOT NULL,
+  sample_table_id INT NOT NULL,
+  PRIMARY KEY (id),
+  FOREIGN KEY (sample_table_id) REFERENCES sample_table(id) ON UPDATE CASCADE
+);

--- a/test/services/database-analyzer/database-analyzer-sequelize.test.js
+++ b/test/services/database-analyzer/database-analyzer-sequelize.test.js
@@ -64,5 +64,16 @@ describe('services > database analyser > Sequelize', () => {
       expect(result.rentals).toStrictEqual(expected.rentals);
       await sequelizeHelper.close();
     }, 10000);
+
+    it('should detect snake_case even with no fields in the table', async () => {
+      expect.assertions(1);
+      const sequelizeHelper = new SequelizeHelper();
+      const databaseConnection = await sequelizeHelper.connect(connectionUrl);
+      await sequelizeHelper.dropAndCreate('sample_table');
+      await sequelizeHelper.dropAndCreate('underscored_no_fields');
+      const result = await performDatabaseAnalysis(databaseConnection);
+      expect(result.underscored_no_fields.options.underscored).toStrictEqual(true);
+      await sequelizeHelper.close();
+    }, 10000);
   });
 });


### PR DESCRIPTION
Fixes [#4embh7](https://app.clickup.com/t/4embh7).

This PR contains to bug fixes in order to correctly handle snake_cased tables that only contain foreign keys.

The issue came from two different bugs in the code :
- The `through` property that is generated when having `belongsToMany` relationships was using the table name as its value, but it's meant to contain the name of the model, which is camelCased in our setup.
- The `options.underscored` property was only computed from the fields names, so if you had no fields but had some snake_cased FKs, it still defaulted to false.

The consequence was that in the schema building step, after having generated your project, Sequelize couldn't find the snake_cased model in the `through` property, and as such created it on its own (which is its normal behaviour) with default values (such as createdAt and updatedAt).

From the documentation :
> ```js
> Movie.belongsToMany(Actor, { through: 'ActorMovies' });
> Actor.belongsToMany(Movie, { through: 'ActorMovies' });
> ```
> Since a string was given in the through option of the belongsToMany call, Sequelize will automatically create the ActorMovies model which will act as the junction model. For example, in PostgreSQL:
>
> ```sql
> CREATE TABLE IF NOT EXISTS "ActorMovies" (
>  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
>  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
>  "MovieId" INTEGER REFERENCES "Movies" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
>  "ActorId" INTEGER REFERENCES "Actors" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
>  PRIMARY KEY ("MovieId","ActorId")
>);
>```

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
