### PR TITLE
refactor: refactor through model name with hasMany relationships

### DIFF
--- a/services/analyzer/sequelize-tables-analyzer.js
+++ b/services/analyzer/sequelize-tables-analyzer.js
@@ -6,6 +6,7 @@ const ColumnTypeGetter = require('./sequelize-column-type-getter');
 const TableConstraintsGetter = require('./sequelize-table-constraints-getter');
 const { DatabaseAnalyzerError } = require('../../utils/errors');
 const { terminate } = require('../../utils/terminator');
+const stringUtils = require('../../utils/strings');
 
 const ASSOCIATION_TYPE_BELONGS_TO = 'belongsTo';
 const ASSOCIATION_TYPE_BELONGS_TO_MANY = 'belongsToMany';
@@ -138,7 +139,9 @@ function createReference(tableName, association, foreignKey, manyToManyForeignKe
   } else if (association === ASSOCIATION_TYPE_BELONGS_TO_MANY) {
     reference.ref = manyToManyForeignKey.foreignTableName;
     reference.otherKey = manyToManyForeignKey.columnName;
-    reference.junctionTable = foreignKey.tableName;
+    reference.through = stringUtils.camelCase(
+      stringUtils.transformToSafeString(foreignKey.tableName),
+    );
   } else {
     reference.ref = foreignKey.tableName;
 

--- a/services/dumper.js
+++ b/services/dumper.js
@@ -205,10 +205,6 @@ function Dumper(config) {
         isBelongsToMany: reference.association === 'belongsToMany',
       };
 
-      if (reference.junctionTable) {
-        computedReference.junctionTable = _.camelCase(reference.junctionTable);
-      }
-
       if (reference.targetKey) {
         const expectedConventionalTargetKeyName = underscored
           ? _.snakeCase(reference.targetKey)

--- a/templates/app/models/sequelize-model.hbs
+++ b/templates/app/models/sequelize-model.hbs
@@ -25,7 +25,7 @@ module.exports = (sequelize, DataTypes) => {
     {{#each references as |reference|}}
     {{../modelVariableName}}.{{reference.association}}(models.{{reference.ref}}, {
     {{#if reference.isBelongsToMany}}
-      through: '{{reference.junctionTable}}',
+      through: '{{reference.through}}',
       foreignKey: '{{reference.foreignKey}}',
       otherKey: '{{reference.otherKey}}',
     {{else}}

--- a/test-expected/sequelize/db-analysis-output/users.expected.json
+++ b/test-expected/sequelize/db-analysis-output/users.expected.json
@@ -29,8 +29,8 @@
         "ref": "books",
         "foreignKey": "user_id",
         "foreignKeyName": "userIdKey",
-        "junctionTable": "user_books",
-        "otherKey": "book_id"
+        "otherKey": "book_id",
+        "through": "userBooks"
       },
       {
         "as": "reviews",


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code

According to https://sequelize.org/master/manual/advanced-many-to-many.html
```
By passing a string to through above, we are asking Sequelize to automatically generate a model named User_Profiles as the through table (also known as junction table), with only two columns: userId and profileId. A composite unique key will be established on these two columns.
```