### PR TITLE
ci(commitlint): dynamically estimate max header length for pull request title on squash and merge

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,19 @@
+// NOTICE: When a github "squash and merge" is performed, github add the PR link in the commit
+//         message using the format ` (#<PR_ID>)`. Travis provide the target branch of the build,
+//         so authorizing 4+5 = 9 characters more on master for the max header length should work
+//         until we reach PR #99999.
+
+let maxHeaderLength = 100;
+
+const prExtrasChars = 9;
+
+const isCommitOnMaster = process.env.TRAVIS_BRANCH && process.env.TRAVIS_BRANCH === 'master';
+
+if (isCommitOnMaster) {
+  maxHeaderLength += prExtrasChars;
+}
+
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  rules: { 'header-max-length': [2, 'always', 100] },
+  rules: { 'header-max-length': [2, 'always', maxHeaderLength] },
 };


### PR DESCRIPTION
## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Create automatic tests
- [ ] No automatic tests failures
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
