### PR TITLE
fix(models): enforce string type for default value when 'NULL'

### DIFF
--- a/services/dumper.js
+++ b/services/dumper.js
@@ -169,14 +169,16 @@ function Dumper(config) {
     if (config.dbDialect !== 'mongodb') {
       if (typeof safeDefaultValue === 'object' && safeDefaultValue instanceof Sequelize.Utils.Literal) {
         safeDefaultValue = `Sequelize.literal('${safeDefaultValue.val}')`;
-      } else if (
-        !_.isNil(safeDefaultValue)
-        && _.some(
+      } else if (!_.isNil(safeDefaultValue)) {
+        if (_.some(
           DEFAULT_VALUE_TYPES_TO_STRINGIFY,
           // NOTICE: Uses `startsWith` as composite types may vary (eg: `ARRAY(DataTypes.INTEGER)`)
           (dataType) => _.startsWith(field.type, dataType),
         )) {
-        safeDefaultValue = JSON.stringify(safeDefaultValue);
+          safeDefaultValue = JSON.stringify(safeDefaultValue);
+        } else if (`${safeDefaultValue}`.toUpperCase() === 'NULL') {
+          safeDefaultValue = '"NULL"';
+        }
       }
     }
     return safeDefaultValue;

--- a/test-expected/sequelize/db-analysis-output/default-values.expected.js
+++ b/test-expected/sequelize/db-analysis-output/default-values.expected.js
@@ -51,6 +51,13 @@ module.exports = {
         "defaultValue": 42
       },
       {
+        "name": 'numericWithStringNULLDefault',
+        "nameColumn": 'numericWithStringNULLDefault',
+        "type": 'DOUBLE',
+        "primaryKey": false,
+        "defaultValue": 'NULL',
+      },
+      {
         "name": "jsonDefault",
         "nameColumn": "jsonDefault",
         "type": "JSONB",

--- a/test-expected/sequelize/dumper-output/default-values.expected.js
+++ b/test-expected/sequelize/dumper-output/default-values.expected.js
@@ -32,6 +32,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INT,
       defaultValue: 42,
     },
+    numericWithStringNULLDefault: {
+      type: DataTypes.DOUBLE,
+      defaultValue: "NULL",
+    },
     jsonDefault: {
       type: DataTypes.JSONB,
       defaultValue: [{"key":"one","isValid":true},{"key":"another","count":21},{"key":"last","value":"string value"}],


### PR DESCRIPTION
Some "NULL" where included in models without quoting due to non-string type for database fields.

eg: DB column type `numeric(12,2)` and default value `NULL::numeric`.

Linked to: CU-78nvya

## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Create automatic tests
- [ ] No automatic tests failures
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
