### PR TITLE
feat: trust SSL certificate by default to ease users onboarding

### DIFF
--- a/templates/app/env.hbs
+++ b/templates/app/env.hbs
@@ -7,6 +7,8 @@ DATABASE_URL={{ databaseUrl }}
 DATABASE_SCHEMA={{ dbSchema }}
 {{/if}}
 DATABASE_SSL={{ ssl }}
+# This should be removed in production environment.
+DATABASE_REJECT_UNAUTHORIZED=false
 
 FOREST_AUTH_SECRET={{ forestAuthSecret }}
 FOREST_ENV_SECRET={{ forestEnvSecret }}

--- a/templates/app/models/index.hbs
+++ b/templates/app/models/index.hbs
@@ -58,7 +58,11 @@ if (process.env.DATABASE_SSL && JSON.parse(process.env.DATABASE_SSL.toLowerCase(
 {{else if isMSSQL}}
   databaseOptions.dialectOptions.options = { encrypt: true };
 {{else}}
-  databaseOptions.dialectOptions.ssl = true;
+  if (process.env.DATABASE_REJECT_UNAUTHORIZED === false) {
+    databaseOptions.dialectOptions.ssl = { rejectUnauthorized: false };
+  } else {
+    databaseOptions.dialectOptions.ssl = true;
+  }
 {{/if}}
 }
 

--- a/test-expected/sequelize/dumper-output/env.expected
+++ b/test-expected/sequelize/dumper-output/env.expected
@@ -1,0 +1,12 @@
+APPLICATION_PORT=1654
+
+CORS_ORIGINS=
+
+DATABASE_URL=postgres://localhost:27017
+DATABASE_SCHEMA=public
+DATABASE_SSL=false
+# This should be removed in production environment.
+DATABASE_REJECT_UNAUTHORIZED=false
+
+FOREST_AUTH_SECRET=
+FOREST_ENV_SECRET=

--- a/test-expected/sequelize/dumper-output/index.expected.js
+++ b/test-expected/sequelize/dumper-output/index.expected.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+
+if (!process.env.DATABASE_URL) {
+  console.error('Cannot connect to the database. Please declare the DATABASE_URL environment variable with the correct database connection string.');
+  process.exit();
+}
+
+const databaseOptions = {
+  logging: process.env.NODE_ENV === 'development' ? console.log : false,
+  pool: { maxConnections: 10, minConnections: 1 },
+  dialectOptions: {},
+};
+
+if (process.env.DATABASE_SSL && JSON.parse(process.env.DATABASE_SSL.toLowerCase())) {
+  if (process.env.DATABASE_REJECT_UNAUTHORIZED === false) {
+    databaseOptions.dialectOptions.ssl = { rejectUnauthorized: false };
+  } else {
+    databaseOptions.dialectOptions.ssl = true;
+  }
+}
+
+const sequelize = new Sequelize(process.env.DATABASE_URL, databaseOptions);
+const db = {};
+
+fs
+  .readdirSync(__dirname)
+  .filter((file) => {
+    return (file.indexOf('.') !== 0) && (file !== 'index.js');
+  })
+  .forEach((file) => {
+    try {
+      const model = sequelize.import(path.join(__dirname, file));
+      db[model.name] = model;
+    } catch (error) {
+      console.error('Model creation error: ' + error);
+    }
+  });
+
+Object.keys(db).forEach((modelName) => {
+  if ('associate' in db[modelName]) {
+    db[modelName].associate(db);
+  }
+});
+
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
+
+module.exports = db;

--- a/test/services/dumper/dumper-sequelize.test.js
+++ b/test/services/dumper/dumper-sequelize.test.js
@@ -84,4 +84,26 @@ describe('services > dumper > sequelize', () => {
     expect(generatedFile).toStrictEqual(expectedFile);
     cleanOutput();
   });
+
+  it('should generate the model index file', async () => {
+    expect.assertions(1);
+    const dumper = await getDumper();
+    await dumper.dump(simpleModel);
+    const generatedFile = fs.readFileSync('./test-output/sequelize/models/index.js', 'utf8');
+    const expectedFile = fs.readFileSync('./test-expected/sequelize/dumper-output/index.expected.js', 'utf-8');
+
+    expect(generatedFile).toStrictEqual(expectedFile);
+    cleanOutput();
+  });
+
+  it('should generate the env file', async () => {
+    expect.assertions(1);
+    const dumper = await getDumper();
+    await dumper.dump(simpleModel);
+    const generatedFile = fs.readFileSync('./test-output/sequelize/.env', 'utf8');
+    const expectedFile = fs.readFileSync('./test-expected/sequelize/dumper-output/env.expected', 'utf-8');
+
+    expect(generatedFile).toStrictEqual(expectedFile);
+    cleanOutput();
+  });
 });


### PR DESCRIPTION
As suggested by @arnaudbesnier, we do not add a `dialectOptions` option. See two dead PRs here: #471 & #468 

Let's add `DATABASE_REJECT_UNAUTHORIZED=false` every time, for each case. It solves P1 and it doesn't try to solve problems that don't exist.

See: 
- https://github.com/ForestAdmin/lumber/issues/452
- https://app.clickup.com/t/82nzna
- https://community.forestadmin.com/t/ssl-issues-with-forestadmin/837
- https://forestadmin.productboard.com/roadmap/1782065-roadmap-forest-by-lanes/features/5553384/insights
- https://forestadmin.slack.com/archives/GCYMMU085/p1599721557051000

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
