### PR TITLE
feat: allow calls from redirections

### DIFF
--- a/templates/app/app.hbs
+++ b/templates/app/app.hbs
@@ -20,7 +20,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
-let allowedOrigins = [/\.forestadmin\.com$/{{#if forestUrl }}, /localhost:\d{4}$/{{/if}}];
+let allowedOrigins = [/\.forestadmin\.com$/, 'null'{{#if forestUrl }}, /localhost:\d{4}$/{{/if}}];
 
 if (process.env.CORS_ORIGINS) {
   allowedOrigins = allowedOrigins.concat(process.env.CORS_ORIGINS.split(','));

--- a/templates/app/app.hbs
+++ b/templates/app/app.hbs
@@ -20,18 +20,25 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
-let allowedOrigins = [/\.forestadmin\.com$/, 'null'{{#if forestUrl }}, /localhost:\d{4}$/{{/if}}];
+let allowedOrigins = [/\.forestadmin\.com$/{{#if forestUrl }}, /localhost:\d{4}$/{{/if}}];
 
 if (process.env.CORS_ORIGINS) {
   allowedOrigins = allowedOrigins.concat(process.env.CORS_ORIGINS.split(','));
 }
 
-app.use(cors({
+const corsConfig = {
   origin: allowedOrigins,
   allowedHeaders: ['Authorization', 'X-Requested-With', 'Content-Type'],
   maxAge: 86400, // NOTICE: 1 day
   credentials: true,
+};
+
+app.use('/forest/authentication', cors({
+  ...corsConfig,
+  origin: corsConfig.origin.concat('null')
 }));
+
+app.use(cors(corsConfig));
 
 app.use(jwt({
   secret: process.env.FOREST_AUTH_SECRET,

--- a/templates/app/app.hbs
+++ b/templates/app/app.hbs
@@ -35,6 +35,9 @@ const corsConfig = {
 
 app.use('/forest/authentication', cors({
   ...corsConfig,
+  // The null origin is sent by browsers for redirected AJAX calls
+  // we need to support this in authentication routes because OIDC
+  // redirects to the callback route
   origin: corsConfig.origin.concat('null')
 }));
 


### PR DESCRIPTION
When an AJAX call is redirected to another endpoint, the origin is set to the string `'null'` instead of the original origin. Servers have to explicitly allow this value and return `null` in the corresponding cors header.

As we are preparing the authentication flow with OIDC, we will need to allow this origin, at least for authentication routes.

I did not find an easy way to let `forest-express` handle these cors declarations and only accept this value for routes that needed it. So the simpler solution is to allow `null` for all routes.


## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Create automatic tests
- [ ] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
