### PR TITLE
fix: generate command could fail when analysing relations on MongoDB when having one or more views

### DIFF
--- a/services/analyzer/mongo-collections-analyzer.js
+++ b/services/analyzer/mongo-collections-analyzer.js
@@ -8,7 +8,10 @@ const {
   getMongooseTypeFromValue,
   isOfMongooseType,
 } = require('../../utils/mongo-primitive-type');
-const { isSystemCollection } = require('../../utils/mongo-collections');
+const {
+  isSystemCollection,
+  getCollectionName,
+} = require('../../utils/mongo-collections');
 const {
   getMongooseArraySchema,
   getMongooseEmbeddedSchema,
@@ -151,10 +154,8 @@ function analyzeMongoCollections(databaseConnection) {
         });
       }
 
-      return P.each(collections, async (item) => {
-        const collection = item.s;
-        const collectionName = collection && collection.namespace
-          && collection.namespace.collection;
+      return P.each(collections, async (collection) => {
+        const collectionName = getCollectionName(collection);
 
         // Ignore system collections and collection without a valid name.
         if (!collectionName || isSystemCollection(collection)) {

--- a/services/analyzer/mongo-collections-analyzer.js
+++ b/services/analyzer/mongo-collections-analyzer.js
@@ -156,9 +156,7 @@ function analyzeMongoCollections(databaseConnection) {
         const collectionName = collection && collection.namespace
           && collection.namespace.collection;
 
-        if (!collectionName) return;
-
-        // Ignore system collections and collection without a fullname;
+        // Ignore system collections and collection without a valid name.
         if (!collectionName || isSystemCollection(collection)) {
           return;
         }

--- a/services/analyzer/mongo-collections-analyzer.js
+++ b/services/analyzer/mongo-collections-analyzer.js
@@ -8,6 +8,7 @@ const {
   getMongooseTypeFromValue,
   isOfMongooseType,
 } = require('../../utils/mongo-primitive-type');
+const { isSystemCollection } = require('../../utils/mongo-collections');
 const {
   getMongooseArraySchema,
   getMongooseEmbeddedSchema,
@@ -155,13 +156,10 @@ function analyzeMongoCollections(databaseConnection) {
         const collectionName = collection && collection.namespace
           && collection.namespace.collection;
 
-        // NOTICE: Defensive programming
-        if (!collectionName) {
-          return;
-        }
+        if (!collectionName) return;
 
-        // NOTICE: Ignore system collections.
-        if (collectionName.startsWith('system.')) {
+        // Ignore system collections and collection without a fullname;
+        if (!collectionName || isSystemCollection(collection)) {
           return;
         }
 

--- a/test-expected/mongo/db-analysis-output/complex-model-with-a-view.expected.json
+++ b/test-expected/mongo/db-analysis-output/complex-model-with-a-view.expected.json
@@ -1,0 +1,71 @@
+{
+  "persons": {
+    "fields": [
+      {
+        "name": "cousin",
+        "type": "mongoose.Schema.Types.ObjectId",
+        "ref": "persons"
+      },
+      {
+        "name": "dad",
+        "type": "mongoose.Schema.Types.ObjectId",
+        "ref": "persons"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "preferredFilm",
+        "type": "mongoose.Schema.Types.ObjectId"
+      },
+      {
+        "name": "son",
+        "type": "mongoose.Schema.Types.ObjectId",
+        "ref": "persons"
+      }
+    ],
+    "references": [],
+    "primaryKeys": [
+      "_id"
+    ],
+    "options": {
+      "timestamps": false
+    }
+  },
+  "films": {
+    "fields": [
+      {
+        "name": "author",
+        "type": "mongoose.Schema.Types.ObjectId",
+        "ref": "persons"
+      },
+      {
+        "name": "bestActor",
+        "type": "mongoose.Schema.Types.ObjectId",
+        "ref": "persons"
+      },
+      {
+        "name": "title",
+        "type": "String"
+      }
+    ],
+    "references": [],
+    "primaryKeys": [
+      "_id"
+    ],
+    "options": {
+      "timestamps": false
+    }
+  },
+  "myView": {
+    "fields": [],
+    "references": [],
+    "primaryKeys": [
+      "_id"
+    ],
+    "options": {
+      "timestamps": false
+    }
+  }
+}

--- a/utils/mongo-collections.js
+++ b/utils/mongo-collections.js
@@ -7,7 +7,7 @@ function isSystemCollection(collection) {
 
 async function findCollectionMatchingSamples(databaseConnection, samples) {
   return P.mapSeries(databaseConnection.collections(), async (collection) => {
-    if (!isSystemCollection(collection)) return null;
+    if (isSystemCollection(collection)) return null;
     const count = await collection.countDocuments({ _id: { $in: samples } });
     if (count) {
       return collection.s.namespace.collection;

--- a/utils/mongo-collections.js
+++ b/utils/mongo-collections.js
@@ -1,0 +1,27 @@
+const P = require('bluebird');
+
+function isSystemCollection(collection) {
+  const collectionName = collection && collection.namespace && collection.namespace.collection;
+  return collectionName && collectionName.startsWith('system.');
+}
+
+async function findCollectionMatchingSamples(databaseConnection, samples) {
+  return P.mapSeries(databaseConnection.collections(), async (collection) => {
+    if (!isSystemCollection(collection)) return null;
+    const count = await collection.countDocuments({ _id: { $in: samples } });
+    if (count) {
+      return collection.s.namespace.collection;
+    }
+    return null;
+  }).then((matches) => matches.filter((match) => match));
+}
+
+function filterReferenceCollection(referencedCollections) {
+  return referencedCollections.length === 1 ? referencedCollections[0] : null;
+}
+
+module.exports = {
+  findCollectionMatchingSamples,
+  isSystemCollection,
+  filterReferenceCollection,
+};

--- a/utils/mongo-collections.js
+++ b/utils/mongo-collections.js
@@ -1,7 +1,14 @@
 const P = require('bluebird');
 
+function getCollectionName(collection) {
+  return collection
+    && collection.s
+    && collection.s.namespace
+    && collection.s.namespace.collection;
+}
+
 function isSystemCollection(collection) {
-  const collectionName = collection && collection.namespace && collection.namespace.collection;
+  const collectionName = getCollectionName(collection);
   return collectionName && collectionName.startsWith('system.');
 }
 
@@ -24,4 +31,5 @@ module.exports = {
   findCollectionMatchingSamples,
   isSystemCollection,
   filterReferenceCollection,
+  getCollectionName,
 };


### PR DESCRIPTION
## Description

This fix is based on Sébastien's suggestion. We have to remove "system" collections every time we use `databaseConnection.collections()`.

## Refactor

👉  To do so, I had to refactor some code to avoid duplicating too much things. @ reviewer, we try to avoid mixing refactoring and a fix. For this particular case, fixing it without refactoring would have resulted maybe in more code than this actual commit. That's why I exceptionally decided to mix refactor and a fix. Feel free to criticize. Also, code climate ask me for **more** refactor in this PR, I will not follow its advice: since `detectReference ` uses sub-functions that are actually different in each files. It would have required too much work to refactor it.

## How to test

Sébastien gave me a sample database that is available in the click-up ticket. This database should fail during database analysis with master and work with this branch.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Create automatic tests
- [ ] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
