### PR TITLE
test: avoid dropAllCollections error when having system tables

### DIFF
--- a/test-utils/mongo-helper.js
+++ b/test-utils/mongo-helper.js
@@ -37,12 +37,11 @@ class MongoHelper {
 
   async dropAllCollections() {
     const collections = await this.db.listCollections().toArray();
-    return Promise.all(collections.map(({ name }) => {
+    return Promise.all(collections
       // System collections are not droppable…
-      if (name.startsWith('system.')) return null;
+      .filter(({ name }) => name.startsWith('system.'))
       // …other collections are.
-      return this.db.collection(name).drop();
-    }));
+      .map(({ name }) => this.db.collection(name).drop()));
   }
 }
 

--- a/test-utils/mongo-helper.js
+++ b/test-utils/mongo-helper.js
@@ -37,7 +37,12 @@ class MongoHelper {
 
   async dropAllCollections() {
     const collections = await this.db.listCollections().toArray();
-    return Promise.all(collections.map(({ name }) => this.db.collection(name).drop()));
+    return Promise.all(collections.map(({ name }) => {
+      // System collections are not droppable…
+      if (name.startsWith('system.')) return null;
+      // …other collections are.
+      return this.db.collection(name).drop();
+    }));
   }
 }
 

--- a/test-utils/mongo-helper.js
+++ b/test-utils/mongo-helper.js
@@ -39,7 +39,7 @@ class MongoHelper {
     const collections = await this.db.listCollections().toArray();
     return Promise.all(collections
       // System collections are not droppable…
-      .filter(({ name }) => name.startsWith('system.'))
+      .filter(({ name }) => !name.startsWith('system.'))
       // …other collections are.
       .map(({ name }) => this.db.collection(name).drop()));
   }


### PR DESCRIPTION
Running the tests _twice_ could lead to this obscure error when `system` tables has been created:

```
MongoError: ns not found
```

In this [PR](https://github.com/ForestAdmin/lumber/pull/485), I created a test on a view: a view automatically creates a system table. This table cannot be dropped, so it has to be ignored (it crashes when you run test twice if you do not ignore it). With this fix, you can run the test ∞ times.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
