### PR TITLE
chore(docker): add dockerhub login step in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ jobs:
       script: commitlint-travis
     - script: yarn lint
       name: Lint JavaScript
+    - script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      name: Login on dockerhub
     - script: sleep 15; yarn test
       before_install: docker-compose up -d
       name: Tests (Node 10)


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Create automatic tests
- [ ] No automatic tests failures
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code

See: https://docs.travis-ci.com/user/docker/#pushing-a-docker-image-to-a-registry. We will not be pushing docker images from here, but the login step is still valid. According to docker new terms of pull limit (https://www.docker.com/increase-rate-limits#:~:text=Anonymous%20and%20Free%20Docker%20Hub,%3A%20toomanyrequests%3A%20Too%20Many%20Requests.&text=You%20have%20reached%20your%20pull%20rate%20limit) this should be enough to double our pull capacity (200 pulls/6h)