### PR TITLE
Align express-jwt version

### DIFF
--- a/services/dumper.js
+++ b/services/dumper.js
@@ -102,7 +102,7 @@ class Dumper {
       debug: '~4.0.1',
       dotenv: '~6.1.0',
       express: '~4.17.1',
-      'express-jwt': '5.3.1',
+      'express-jwt': '6.0.0',
       [`forest-express-${orm}`]: '^7.0.0',
       morgan: '1.9.1',
       'require-all': '^3.0.0',


### PR DESCRIPTION
Quick PR just to raise the issue, you might need other changes like specifying `algorithms` in express-jwt

---

- 6.0.0 is the one ultimately required by `forest-express-${orm}` ^7.0.0
- versions < 5.3.3 are affected by https://github.com/advisories/GHSA-6g6m-m6h5-w9gf, but it's not picked up by dependabot on this repo
